### PR TITLE
fix: remove season overlay on creative and spectator modes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.6+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=0.1.1
 maven_group=net.abakath.rpg4fools
 archives_base_name=rpg4fools
 

--- a/src/main/java/net/abakath/rpg4fools/client/SeasonsHudOverlay.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonsHudOverlay.java
@@ -18,6 +18,11 @@ public class SeasonsHudOverlay implements HudRenderCallback {
     MinecraftClient client = MinecraftClient.getInstance();
 
     assert client != null;
+    assert client.player != null;
+    if (client.player.isInCreativeMode() || client.player.isSpectator()) {
+      return;
+    }
+
     assert client.world != null;
     if (!client.world.getRegistryKey().equals(World.OVERWORLD)) {
       return;
@@ -29,7 +34,6 @@ public class SeasonsHudOverlay implements HudRenderCallback {
     int x = getHalf(width) - getHalf(SEASON_OVERLAY_SCALE);
     int y = height - (SEASON_OVERLAY_SCALE * 3);
 
-    assert client.player != null;
     IEntityDataSaver playerData = (IEntityDataSaver) client.player;
 
     int year = playerData.getPersistentData().getInt("rpg4fools.year");


### PR DESCRIPTION
remove season overlay on creative and spectator modes