### PR TITLE
fix: tornar SeasonData null safe e evitar markDirty a cada tick

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/server/SeasonData.java
+++ b/src/main/java/net/abakath/rpg4fools/server/SeasonData.java
@@ -12,8 +12,14 @@ import net.minecraft.world.World;
 import java.util.Objects;
 
 public class SeasonData extends PersistentState {
-  public final String KEY = "season";
-  public SubSeason subSeason;
+  private static final String KEY = "season";
+  private static final SubSeason DEFAULT_SUB_SEASON = SubSeason.EARLY_SPRING;
+
+  /**
+   * Never null. A brand new world sits at time 0, where DayChangingHandler bails out before it can
+   * assign a value, so the field has to carry a sane default of its own.
+   */
+  private SubSeason subSeason = DEFAULT_SUB_SEASON;
 
   private static final Type<SeasonData> type = new Type<>(
           SeasonData::new,
@@ -24,7 +30,10 @@ public class SeasonData extends PersistentState {
   public static SeasonData createFromNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
     SeasonData seasonData = new SeasonData();
 
-    seasonData.subSeason = SubSeason.values()[nbt.getInt("season")];
+    int ordinal = nbt.getInt(KEY);
+    SubSeason[] values = SubSeason.values();
+
+    seasonData.subSeason = ordinal >= 0 && ordinal < values.length ? values[ordinal] : DEFAULT_SUB_SEASON;
 
     return seasonData;
   }
@@ -35,13 +44,26 @@ public class SeasonData extends PersistentState {
     return nbt;
   }
 
+  public SubSeason getSubSeason() {
+    return subSeason;
+  }
+
+  /**
+   * Only marks the state dirty when the value actually changes, so the world save is not forced to
+   * rewrite this state on every tick.
+   */
+  public void setSubSeason(SubSeason subSeason) {
+    if (subSeason == null || subSeason == this.subSeason) {
+      return;
+    }
+
+    this.subSeason = subSeason;
+    this.markDirty();
+  }
+
   public static SeasonData getServerState(MinecraftServer server) {
     PersistentStateManager persistentStateManager = Objects.requireNonNull(server.getWorld(World.OVERWORLD)).getPersistentStateManager();
 
-    SeasonData seasonData = persistentStateManager.getOrCreate(type, RPG4Fools.MOD_ID);
-
-    seasonData.markDirty();
-
-    return seasonData;
+    return persistentStateManager.getOrCreate(type, RPG4Fools.MOD_ID);
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
@@ -28,7 +28,7 @@ public class DayChangingHandler implements ServerTickEvents.StartTick {
             DayData dayData = getDayData(time);
             SeasonData seasonData = SeasonData.getServerState(server);
 
-            seasonData.subSeason = dayData.getMonth().getSubSeason();
+            seasonData.setSubSeason(dayData.getMonth().getSubSeason());
 
             server.getPlayerManager().getPlayerList().forEach(player -> {
                 DayData.setPlayerDayData((IEntityDataSaver) player, dayData);


### PR DESCRIPTION
## Descrição

Um mundo novo começa em `time 0`, e o `DayChangingHandler` faz `return` antes de atribuir a sub season. Isso deixava `SeasonData.subSeason` como `null`, o que gerava `NullPointerException` no `switch` de season assim que qualquer coisa lia o valor.

Além disso, `getServerState` chamava `markDirty()` em toda invocação — ou seja, a cada tick — forçando o world save a reescrever esse state continuamente.

## Alterações

- `subSeason` passa a ter default `EARLY_SPRING` no próprio field, então nunca é `null`.
- `createFromNbt` valida o ordinal lido do NBT contra o range válido, protegendo contra save corrompido.
- Acesso direto ao field vira `getSubSeason()` / `setSubSeason()`. O `setSubSeason` só chama `markDirty()` quando o valor realmente muda.
- `KEY` vira `private static final`. Antes era um field de instância `public`.
- `DayChangingHandler` passa a usar o setter.

## Como testar

1. Criar um mundo novo e confirmar que não há `NullPointerException` no log ao entrar.
2. Com `doDaylightCycle false` e `time set 0`, confirmar que o mundo carrega normalmente (esse era o caso que quebrava).
3. Avançar o tempo até virar de mês e confirmar que a sub season persiste após sair e voltar ao mundo.

## Contexto

Parte 2 de 5 da feature `improve-season-world-colors`. Depende de `fix/move-season-colors-to-client` (base deste PR).
