### PR TITLE
refactor: substituir conversão de cor do java.awt por math sem alocação

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/ColorMath.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ColorMath.java
@@ -1,0 +1,125 @@
+package net.abakath.rpg4fools.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+/**
+ * Allocation free HSB helpers for packed 0xRRGGBB ints.
+ *
+ * <p>These run once per tinted quad on every chunk rebuild, so the whole point is that they touch
+ * no objects. {@link java.awt.Color} was previously used here and allocated a Color plus a float[3]
+ * per call, which adds up to millions of allocations per world reload. AWT is also an awkward
+ * dependency to pull into a Minecraft client.
+ */
+@Environment(EnvType.CLIENT)
+public final class ColorMath {
+  private ColorMath() {
+  }
+
+  /**
+   * Converts a packed RGB colour to HSB and writes the result into {@code out}.
+   *
+   * @param out a caller owned float[3] receiving hue, saturation and brightness, each in 0..1
+   */
+  public static void rgbToHsb(int rgb, float[] out) {
+    int r = (rgb >> 16) & 0xFF;
+    int g = (rgb >> 8) & 0xFF;
+    int b = rgb & 0xFF;
+
+    int max = Math.max(r, Math.max(g, b));
+    int min = Math.min(r, Math.min(g, b));
+    int delta = max - min;
+
+    float brightness = max / 255.0f;
+    float saturation = max == 0 ? 0.0f : (float) delta / max;
+    float hue = 0.0f;
+
+    if (delta != 0) {
+      float rc = (float) (max - r) / delta;
+      float gc = (float) (max - g) / delta;
+      float bc = (float) (max - b) / delta;
+
+      if (r == max) {
+        hue = bc - gc;
+      } else if (g == max) {
+        hue = 2.0f + rc - bc;
+      } else {
+        hue = 4.0f + gc - rc;
+      }
+
+      hue /= 6.0f;
+      if (hue < 0.0f) {
+        hue += 1.0f;
+      }
+    }
+
+    out[0] = hue;
+    out[1] = saturation;
+    out[2] = brightness;
+  }
+
+  /**
+   * Converts HSB back to a packed 0xRRGGBB int. Inputs are clamped, and hue wraps.
+   */
+  public static int hsbToRgb(float hue, float saturation, float brightness) {
+    saturation = clamp01(saturation);
+    brightness = clamp01(brightness);
+
+    hue = hue - (float) Math.floor(hue);
+
+    int r = 0;
+    int g = 0;
+    int b = 0;
+
+    if (saturation == 0.0f) {
+      r = g = b = Math.round(brightness * 255.0f);
+    } else {
+      float h = hue * 6.0f;
+      int sector = (int) Math.floor(h);
+      float f = h - sector;
+
+      float p = brightness * (1.0f - saturation);
+      float q = brightness * (1.0f - saturation * f);
+      float t = brightness * (1.0f - saturation * (1.0f - f));
+
+      switch (sector) {
+        case 0 -> {
+          r = Math.round(brightness * 255.0f);
+          g = Math.round(t * 255.0f);
+          b = Math.round(p * 255.0f);
+        }
+        case 1 -> {
+          r = Math.round(q * 255.0f);
+          g = Math.round(brightness * 255.0f);
+          b = Math.round(p * 255.0f);
+        }
+        case 2 -> {
+          r = Math.round(p * 255.0f);
+          g = Math.round(brightness * 255.0f);
+          b = Math.round(t * 255.0f);
+        }
+        case 3 -> {
+          r = Math.round(p * 255.0f);
+          g = Math.round(q * 255.0f);
+          b = Math.round(brightness * 255.0f);
+        }
+        case 4 -> {
+          r = Math.round(t * 255.0f);
+          g = Math.round(p * 255.0f);
+          b = Math.round(brightness * 255.0f);
+        }
+        default -> {
+          r = Math.round(brightness * 255.0f);
+          g = Math.round(p * 255.0f);
+          b = Math.round(q * 255.0f);
+        }
+      }
+    }
+
+    return (r << 16) | (g << 8) | b;
+  }
+
+  public static float clamp01(float value) {
+    return value < 0.0f ? 0.0f : Math.min(value, 1.0f);
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
@@ -9,8 +9,6 @@ import net.minecraft.block.Blocks;
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.item.Items;
 
-import java.awt.Color;
-
 /**
  * Registers the season aware block and item tints.
  *
@@ -37,6 +35,12 @@ public final class SeasonColorProviders {
           Blocks.FERN,
           Blocks.LARGE_FERN
   };
+
+  /**
+   * Chunk building runs on several worker threads, so the scratch buffer used by the colour
+   * conversion is per thread. This keeps the tint path free of allocations.
+   */
+  private static final ThreadLocal<float[]> HSB_SCRATCH = ThreadLocal.withInitial(() -> new float[3]);
 
   private SeasonColorProviders() {
   }
@@ -69,12 +73,10 @@ public final class SeasonColorProviders {
   }
 
   private static int adjustSaturation(int rgb, float saturationFactor) {
-    Color color = new Color(rgb);
-    float[] hsbVals = Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), null);
+    float[] hsb = HSB_SCRATCH.get();
+    ColorMath.rgbToHsb(rgb, hsb);
 
-    hsbVals[1] = Math.min(1.0f, hsbVals[1] * saturationFactor);
-
-    return Color.HSBtoRGB(hsbVals[0], hsbVals[1], hsbVals[2]);
+    return ColorMath.hsbToRgb(hsb[0], hsb[1] * saturationFactor, hsb[2]);
   }
 
   private static int getDefaultFoliageColor(Block block) {


### PR DESCRIPTION
## Descrição

`adjustSaturation` roda uma vez por quad tingido em cada rebuild de chunk. Cada chamada alocava um `java.awt.Color` mais o `float[3]` devolvido por `Color.RGBtoHSB` — ou seja, milhões de alocações por reload de mundo. Fora isso, AWT é uma dependência ruim de puxar para dentro de um client de Minecraft.

Refactor puro: **nenhuma mudança de comportamento visual**. Prepara o terreno para o novo modelo de cor (parte 4).

## Alterações

- Adiciona `ColorMath` com `rgbToHsb` / `hsbToRgb` operando sobre ints `0xRRGGBB`, escrevendo em um buffer do caller em vez de alocar um novo.
- `SeasonColorProviders` ganha um scratch buffer por thread (`ThreadLocal`), já que o chunk building roda em várias worker threads.
- Remove o uso de `java.awt.Color`.

O clamp de saturação continua existindo: `hsbToRgb` já faz `clamp01`, que é exatamente o que o antigo `Math.min(1.0f, ...)` fazia.

## Como testar

1. Rodar o client e comparar as cores de grama e folhas com a branch anterior — devem estar idênticas em todas as sub seasons.
2. Avançar o tempo por um ano completo e confirmar que cada sub season renderiza o mesmo tom de antes.
3. Opcional: com um profiler, confirmar a queda de alocação durante um `worldRenderer.reload()`.

## Contexto

Parte 3 de 5 da feature `improve-season-world-colors`. Depende de `fix/season-data-null-safety` (base deste PR).
