### PR TITLE
feat: modelo de cor por hue e brightness, não só saturação

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/ClientModMessages.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ClientModMessages.java
@@ -32,7 +32,7 @@ public final class ClientModMessages {
       player.getPersistentData().putInt("rpg4fools.day", packet.dayData.getDay());
       player.getPersistentData().putLong("rpg4fools.dayTime", packet.dayData.getDayTime());
 
-      ClientSeasonState.update(packet.dayData.getMonth().ordinal());
+      ClientSeasonState.update(packet.dayData.getMonth().ordinal(), packet.dayData.getDay());
     });
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/client/ClientSeasonState.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ClientSeasonState.java
@@ -11,12 +11,24 @@ import net.minecraft.client.MinecraftClient;
  *
  * <p>The season only ever affects rendering, so the client keeps its own copy instead of
  * reaching for the server-side {@link net.abakath.rpg4fools.server.SeasonData}. The value is
- * derived from the month carried by
+ * derived from the date carried by
  * {@link net.abakath.rpg4fools.network.packets.s2c.SeasonUpdatePacket}.
+ *
+ * <p>The day within the month is tracked as well, so the tint can be interpolated towards the next
+ * sub season instead of snapping on the first of the month.
  */
 @Environment(EnvType.CLIENT)
 public final class ClientSeasonState {
+  /** Days in a month, matching DayChangingHandler.MONTH_DURATION. */
+  private static final int MONTH_DURATION = 28;
+
   private static volatile SubSeason subSeason = SubSeason.EARLY_SPRING;
+
+  /** Progress through the current sub season, 0 on the first day and approaching 1 on the last. */
+  private static volatile float progress = 0.0f;
+
+  private static int lastMonth = -1;
+  private static int lastDay = -1;
 
   private ClientSeasonState() {
   }
@@ -25,24 +37,33 @@ public final class ClientSeasonState {
     return subSeason;
   }
 
+  public static float getProgress() {
+    return progress;
+  }
+
   /**
-   * Updates the cached season from a month ordinal. When the sub season actually changes the
-   * world renderer is reloaded so every chunk picks up the new tint.
+   * Updates the cached season from the current date. When the rendered tint changes the world
+   * renderer is reloaded so every chunk picks up the new colour.
+   *
+   * <p>The tint moves once per in game day, so this triggers one renderer reload per day rather
+   * than one per sub season. That is a deliberate trade of a rebuild for a smooth transition.
    *
    * <p>Must be called from the client thread.
    */
-  public static void update(int monthOrdinal) {
+  public static void update(int monthOrdinal, int day) {
     if (monthOrdinal < 0 || monthOrdinal >= Months.values().length) {
       return;
     }
 
-    SubSeason newSubSeason = Months.values()[monthOrdinal].getSubSeason();
-
-    if (newSubSeason == subSeason) {
+    if (monthOrdinal == lastMonth && day == lastDay) {
       return;
     }
 
-    subSeason = newSubSeason;
+    lastMonth = monthOrdinal;
+    lastDay = day;
+
+    subSeason = Months.values()[monthOrdinal].getSubSeason();
+    progress = ColorMath.clamp01((float) (day - 1) / MONTH_DURATION);
 
     MinecraftClient client = MinecraftClient.getInstance();
     if (client.worldRenderer != null) {

--- a/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
@@ -1,6 +1,5 @@
 package net.abakath.rpg4fools.client;
 
-import net.abakath.rpg4fools.enums.SubSeason;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
@@ -50,7 +49,7 @@ public final class SeasonColorProviders {
       if (world == null || pos == null) {
         return -1;
       }
-      return adjustSaturation(BiomeColors.getGrassColor(world, pos), getSeasonSaturation());
+      return applySeasonTint(BiomeColors.getGrassColor(world, pos));
     }, GRASS_BLOCKS);
 
     // TODO: Add coloring to flowers, vines and more
@@ -59,7 +58,7 @@ public final class SeasonColorProviders {
       if (world == null || pos == null) {
         return -1;
       }
-      return adjustSaturation(BiomeColors.getFoliageColor(world, pos), getSeasonSaturation());
+      return applySeasonTint(BiomeColors.getFoliageColor(world, pos));
     }, FOLIAGE_BLOCKS);
 
     ColorProviderRegistry.ITEM.register((stack, tintIndex) -> 0x91BD59, Items.GRASS_BLOCK, Items.SHORT_GRASS, Items.TALL_GRASS, Items.FERN, Items.LARGE_FERN);
@@ -72,11 +71,32 @@ public final class SeasonColorProviders {
     }, FOLIAGE_BLOCKS);
   }
 
-  private static int adjustSaturation(int rgb, float saturationFactor) {
+  /**
+   * Grades a biome colour by the current season. The tint is interpolated between the current sub
+   * season and the next one across the month, so the year reads as a gradual shift rather than
+   * twelve hard steps.
+   */
+  private static int applySeasonTint(int rgb) {
+    SeasonTint current = SeasonTint.of(ClientSeasonState.getSubSeason());
+    SeasonTint next = current.next();
+    float t = ClientSeasonState.getProgress();
+
+    float hueShift = lerp(current.getHueShift(), next.getHueShift(), t);
+    float saturationFactor = lerp(current.getSaturationFactor(), next.getSaturationFactor(), t);
+    float brightnessFactor = lerp(current.getBrightnessFactor(), next.getBrightnessFactor(), t);
+
     float[] hsb = HSB_SCRATCH.get();
     ColorMath.rgbToHsb(rgb, hsb);
 
-    return ColorMath.hsbToRgb(hsb[0], hsb[1] * saturationFactor, hsb[2]);
+    return ColorMath.hsbToRgb(
+            hsb[0] + hueShift,
+            hsb[1] * saturationFactor,
+            hsb[2] * brightnessFactor
+    );
+  }
+
+  private static float lerp(float from, float to, float t) {
+    return from + (to - from) * t;
   }
 
   private static int getDefaultFoliageColor(Block block) {
@@ -91,17 +111,4 @@ public final class SeasonColorProviders {
     }
   }
 
-  private static float getSeasonSaturation() {
-    SubSeason subSeason = ClientSeasonState.getSubSeason();
-
-    return switch (subSeason) {
-      case MID_WINTER -> 0.5f;
-      case EARLY_WINTER, LATE_WINTER -> 0.7f;
-      case LATE_AUTUMN, EARLY_SPRING -> 0.8f;
-      case MID_SPRING, MID_AUTUMN -> 1.0f;
-      case LATE_SPRING, EARLY_AUTUMN -> 1.2f;
-      case EARLY_SUMMER, LATE_SUMMER -> 1.3f;
-      case MID_SUMMER -> 1.5f;
-    };
-  }
 }

--- a/src/main/java/net/abakath/rpg4fools/client/SeasonTint.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonTint.java
@@ -1,0 +1,79 @@
+package net.abakath.rpg4fools.client;
+
+import net.abakath.rpg4fools.enums.SubSeason;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+/**
+ * Per sub season colour grade applied on top of the biome colour.
+ *
+ * <p>Saturation alone cannot express a season. Autumn has to walk the hue from green towards
+ * orange and brown, and winter has to drop saturation while lifting brightness so it reads as pale
+ * frost rather than dark olive. So each sub season carries a hue shift, a saturation factor and a
+ * brightness factor.
+ *
+ * <p>Hue shifts are stored in degrees for readability and converted to the 0..1 hue space used by
+ * {@link ColorMath}. Grass sits around hue 88 degrees, so a negative shift walks green to yellow to
+ * orange to brown.
+ *
+ * <p>Shifts stay close between neighbouring sub seasons on purpose. The values are interpolated
+ * linearly across the month, so a large jump would sweep the hue through every colour in between.
+ * Winter therefore reads as pale frost through low saturation and high brightness rather than
+ * through a swing towards blue, which would have to travel back across green to get there.
+ */
+@Environment(EnvType.CLIENT)
+public enum SeasonTint {
+  EARLY_SPRING(SubSeason.EARLY_SPRING, 5.0f, 0.85f, 1.05f),
+  MID_SPRING(SubSeason.MID_SPRING, 0.0f, 1.05f, 1.05f),
+  LATE_SPRING(SubSeason.LATE_SPRING, 0.0f, 1.15f, 1.0f),
+  EARLY_SUMMER(SubSeason.EARLY_SUMMER, -3.0f, 1.2f, 1.0f),
+  MID_SUMMER(SubSeason.MID_SUMMER, -5.0f, 1.3f, 0.95f),
+  LATE_SUMMER(SubSeason.LATE_SUMMER, -12.0f, 1.15f, 0.95f),
+  EARLY_AUTUMN(SubSeason.EARLY_AUTUMN, -30.0f, 1.1f, 1.0f),
+  MID_AUTUMN(SubSeason.MID_AUTUMN, -50.0f, 1.15f, 0.95f),
+  LATE_AUTUMN(SubSeason.LATE_AUTUMN, -62.0f, 0.9f, 0.85f),
+  EARLY_WINTER(SubSeason.EARLY_WINTER, -70.0f, 0.45f, 0.85f),
+  MID_WINTER(SubSeason.MID_WINTER, -75.0f, 0.15f, 1.15f),
+  LATE_WINTER(SubSeason.LATE_WINTER, -40.0f, 0.30f, 1.05f);
+
+  private static final float DEGREES_IN_CIRCLE = 360.0f;
+
+  private final SubSeason subSeason;
+  private final float hueShiftDegrees;
+  private final float saturationFactor;
+  private final float brightnessFactor;
+
+  SeasonTint(SubSeason subSeason, float hueShiftDegrees, float saturationFactor, float brightnessFactor) {
+    this.subSeason = subSeason;
+    this.hueShiftDegrees = hueShiftDegrees;
+    this.saturationFactor = saturationFactor;
+    this.brightnessFactor = brightnessFactor;
+  }
+
+  public SubSeason getSubSeason() {
+    return subSeason;
+  }
+
+  public float getHueShift() {
+    return hueShiftDegrees / DEGREES_IN_CIRCLE;
+  }
+
+  public float getSaturationFactor() {
+    return saturationFactor;
+  }
+
+  public float getBrightnessFactor() {
+    return brightnessFactor;
+  }
+
+  public static SeasonTint of(SubSeason subSeason) {
+    return values()[subSeason.ordinal()];
+  }
+
+  /**
+   * The tint that follows this one in the yearly cycle, wrapping from LATE_WINTER to EARLY_SPRING.
+   */
+  public SeasonTint next() {
+    return values()[(ordinal() + 1) % values().length];
+  }
+}


### PR DESCRIPTION
## Descrição

O modelo antigo só escalava saturação, e é por isso que as seasons ficavam visualmente sem graça. Dois problemas concretos:

- **Outono nunca ficava laranja.** `EARLY_AUTUMN` era `1.2` e `MID_AUTUMN` era `1.0` — ou seja, o outono era *mais* saturado que a primavera. As folhas continuavam verdes, só que mais vibrantes. Isso contradiz o próprio texto do HUD: *"The leaves begins to paint the ground..."*.
- **Inverno ficava "sujo", não frio.** Saturação `0.5` com brightness intocado dá um verde-oliva escuro, não geada.

Hue e brightness precisam se mover junto com a saturação.

## Alterações

- Adiciona `SeasonTint`: por sub season, um hue shift, um fator de saturação e um fator de brightness. A grama fica perto de hue 88°, então os shifts negativos ao longo do outono caminham verde → amarelo → laranja → marrom.
- Interpola o grade entre a sub season atual e a próxima ao longo dos 28 dias do mês, então o ano vira uma transição gradual em vez de 12 degraus secos.
- `ClientSeasonState` passa a guardar o dia do mês para alimentar essa interpolação.

## Decisões que valem revisão

1. **Inverno não usa hue azul.** A tabela original da proposta levava o `MID_WINTER` para ciano (+100°). Como os valores são interpolados linearmente, sair de marrom (−70°) para ciano (+100°) varre ~170° de hue e passaria *de volta pelo verde* no meio do caminho. Então o inverno ganha o tom pálido via saturação baixa (`0.15`) e brightness alto (`1.15`). Shifts vizinhos ficam propositalmente próximos.

2. **Reload por dia, não por sub season.** Como o tint muda diariamente, o `worldRenderer.reload()` passa a rodar 1x por dia in-game em vez de 1x por sub season. É o custo da transição suave. Se o rebuild incomodar, dá para quantizar o `progress` em menos passos.

## Como testar

1. `time set` avançando mês a mês e conferir a progressão: primavera clara → verão saturado → outono laranja/marrom → inverno pálido.
2. Confirmar que dentro de um mesmo mês a cor muda gradualmente dia a dia, sem salto no dia 1.
3. Conferir especificamente `MID_AUTUMN` — as folhas devem estar visivelmente laranja/marrom, que é o principal objetivo deste PR.
4. Conferir a virada `LATE_WINTER` → `EARLY_SPRING` e garantir que não há salto brusco de cor.

## Contexto

Parte 4 de 5 da feature `improve-season-world-colors`. Depende de `refactor/season-color-math` (base deste PR).
