### PR TITLE
feat: ampliar cobertura do tint de season e respeitar tintIndex

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
@@ -6,6 +6,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.color.world.BiomeColors;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.Items;
 
 /**
@@ -14,25 +15,42 @@ import net.minecraft.item.Items;
  * <p>Block tinting is purely a rendering concern, so this runs from the client entrypoint and is
  * registered exactly once. Colour providers are looked up on every chunk rebuild, which is what
  * makes the tint follow {@link ClientSeasonState} without any re-registration.
+ *
+ * <p>Blocks fall into two groups. Most grass and leaf blocks are biome tinted, so the season grade
+ * is applied on top of whatever {@link BiomeColors} returns. A few are not biome tinted in vanilla
+ * and instead carry a fixed colour, so the grade is applied to that constant instead.
  */
 @Environment(EnvType.CLIENT)
 public final class SeasonColorProviders {
-  private static final Block[] FOLIAGE_BLOCKS = {
-          Blocks.OAK_LEAVES,
-          Blocks.SPRUCE_LEAVES,
-          Blocks.BIRCH_LEAVES,
-          Blocks.JUNGLE_LEAVES,
-          Blocks.ACACIA_LEAVES,
-          Blocks.DARK_OAK_LEAVES,
-          Blocks.MANGROVE_LEAVES
-  };
+  /** Vanilla tint index for the tinted quads of grass and leaf models. */
+  private static final int TINTED_LAYER = 0;
 
+  private static final int DEFAULT_GRASS_COLOR = 0x91BD59;
+  private static final int DEFAULT_FOLIAGE_COLOR = 0x48B518;
+  private static final int BIRCH_FOLIAGE_COLOR = 0x80A755;
+  private static final int SPRUCE_FOLIAGE_COLOR = 0x619961;
+  private static final int MANGROVE_FOLIAGE_COLOR = 0x92C648;
+  private static final int LILY_PAD_COLOR = 0x208030;
+
+  /** Blocks vanilla tints from the biome grass colour. */
   private static final Block[] GRASS_BLOCKS = {
           Blocks.GRASS_BLOCK,
           Blocks.SHORT_GRASS,
           Blocks.TALL_GRASS,
           Blocks.FERN,
-          Blocks.LARGE_FERN
+          Blocks.LARGE_FERN,
+          Blocks.POTTED_FERN,
+          Blocks.SUGAR_CANE
+  };
+
+  /** Blocks vanilla tints from the biome foliage colour. */
+  private static final Block[] FOLIAGE_BLOCKS = {
+          Blocks.OAK_LEAVES,
+          Blocks.JUNGLE_LEAVES,
+          Blocks.ACACIA_LEAVES,
+          Blocks.DARK_OAK_LEAVES,
+          Blocks.MANGROVE_LEAVES,
+          Blocks.VINE
   };
 
   /**
@@ -45,30 +63,72 @@ public final class SeasonColorProviders {
   }
 
   public static void register() {
+    registerBiomeTintedBlocks();
+    registerFixedColorBlocks();
+    registerItems();
+  }
+
+  private static void registerBiomeTintedBlocks() {
     ColorProviderRegistry.BLOCK.register((state, world, pos, tintIndex) -> {
-      if (world == null || pos == null) {
+      if (tintIndex != TINTED_LAYER) {
         return -1;
+      }
+      if (world == null || pos == null) {
+        return applySeasonTint(DEFAULT_GRASS_COLOR);
       }
       return applySeasonTint(BiomeColors.getGrassColor(world, pos));
     }, GRASS_BLOCKS);
 
-    // TODO: Add coloring to flowers, vines and more
-
     ColorProviderRegistry.BLOCK.register((state, world, pos, tintIndex) -> {
-      if (world == null || pos == null) {
+      if (tintIndex != TINTED_LAYER) {
         return -1;
+      }
+      if (world == null || pos == null) {
+        return applySeasonTint(DEFAULT_FOLIAGE_COLOR);
       }
       return applySeasonTint(BiomeColors.getFoliageColor(world, pos));
     }, FOLIAGE_BLOCKS);
+  }
 
-    ColorProviderRegistry.ITEM.register((stack, tintIndex) -> 0x91BD59, Items.GRASS_BLOCK, Items.SHORT_GRASS, Items.TALL_GRASS, Items.FERN, Items.LARGE_FERN);
-    ColorProviderRegistry.ITEM.register((stack, tintIndex) -> {
-      Block block = Block.getBlockFromItem(stack.getItem());
-      if (block != null) {
-        return getDefaultFoliageColor(block);
-      }
-      return -1;
-    }, FOLIAGE_BLOCKS);
+  /**
+   * Birch, spruce and lily pads are not biome tinted in vanilla. They use a constant, so the season
+   * grade is applied to that constant rather than to a biome lookup.
+   *
+   * <p>Cherry and azalea leaves are deliberately left out. Their models carry no tintindex, so a
+   * colour provider would never be consulted. Tinting them means shipping model overrides, which is
+   * left for a follow up. The same applies to flowers.
+   */
+  private static void registerFixedColorBlocks() {
+    registerFixedColorBlock(Blocks.BIRCH_LEAVES, BIRCH_FOLIAGE_COLOR);
+    registerFixedColorBlock(Blocks.SPRUCE_LEAVES, SPRUCE_FOLIAGE_COLOR);
+    registerFixedColorBlock(Blocks.LILY_PAD, LILY_PAD_COLOR);
+  }
+
+  private static void registerFixedColorBlock(Block block, int baseColor) {
+    ColorProviderRegistry.BLOCK.register(
+            (state, world, pos, tintIndex) -> tintIndex == TINTED_LAYER ? applySeasonTint(baseColor) : -1,
+            block
+    );
+  }
+
+  /**
+   * Inventory icons follow the season too. Previously the grass items were pinned to a constant and
+   * the leaf items to their vanilla colour, so the inventory disagreed with the world.
+   */
+  private static void registerItems() {
+    registerFixedColorItem(DEFAULT_GRASS_COLOR, Items.GRASS_BLOCK, Items.SHORT_GRASS, Items.TALL_GRASS, Items.FERN, Items.LARGE_FERN, Items.SUGAR_CANE);
+    registerFixedColorItem(DEFAULT_FOLIAGE_COLOR, Items.OAK_LEAVES, Items.JUNGLE_LEAVES, Items.ACACIA_LEAVES, Items.DARK_OAK_LEAVES, Items.VINE);
+    registerFixedColorItem(BIRCH_FOLIAGE_COLOR, Items.BIRCH_LEAVES);
+    registerFixedColorItem(SPRUCE_FOLIAGE_COLOR, Items.SPRUCE_LEAVES);
+    registerFixedColorItem(MANGROVE_FOLIAGE_COLOR, Items.MANGROVE_LEAVES);
+    registerFixedColorItem(LILY_PAD_COLOR, Items.LILY_PAD);
+  }
+
+  private static void registerFixedColorItem(int baseColor, ItemConvertible... items) {
+    ColorProviderRegistry.ITEM.register(
+            (stack, tintIndex) -> tintIndex == TINTED_LAYER ? applySeasonTint(baseColor) : -1,
+            items
+    );
   }
 
   /**
@@ -98,17 +158,4 @@ public final class SeasonColorProviders {
   private static float lerp(float from, float to, float t) {
     return from + (to - from) * t;
   }
-
-  private static int getDefaultFoliageColor(Block block) {
-    if (block == Blocks.BIRCH_LEAVES) {
-      return 0x80a755;
-    } else if (block == Blocks.SPRUCE_LEAVES) {
-      return 0x619961;
-    } else if (block == Blocks.MANGROVE_LEAVES) {
-      return 0x92c648;
-    } else {
-      return 0x48b518;
-    }
-  }
-
 }


### PR DESCRIPTION
## Descrição

Fecha três problemas no conjunto de color providers e amplia a cobertura de blocos.

## Alterações

**Fonte de cor errada.** Vanilla **não** faz biome tint em birch e spruce leaves — elas usam uma constante de `FoliageColors`. Rodar `BiomeColors.getFoliageColor` nelas estava errado. `LILY_PAD` é o mesmo caso. Agora o grade de season é aplicado sobre a cor fixa correta.

**`tintIndex` ignorado.** Os providers devolviam cor para qualquer layer, o que tinge quads que não deveriam ser tingidos. Agora devolvem `-1` para qualquer coisa diferente do layer `0`.

**Itens não seguiam a season.** Os itens de grama estavam fixos em `0x91BD59` e os de folha na cor vanilla, então o inventário discordava do mundo. Agora ambos passam pelo mesmo grade.

**Cobertura.** Adiciona `VINE`, `SUGAR_CANE` e `POTTED_FERN`, que o vanilla tinge mas o mod não cobria.

## Fora de escopo (com motivo)

`CHERRY_LEAVES`, `AZALEA_LEAVES` e `FLOWERING_AZALEA_LEAVES` ficaram de fora **de propósito**: os models delas não têm `tintindex`, então um color provider nunca é consultado. Tingir essas folhas exige shippar override de model, o que é trabalho separado. O mesmo vale para flores. O `TODO` antigo foi substituído por uma nota explicando isso, para não parecer esquecimento.

## Como testar

1. Conferir birch e spruce leaves: devem seguir a season a partir da cor fixa correta, sem variar por bioma.
2. Conferir vine, sugar cane, potted fern e lily pad seguindo a season.
3. Abrir o inventário em sub seasons diferentes e confirmar que os ícones acompanham a cor do mundo.
4. Confirmar que nenhum bloco ganhou tint em layer que não deveria (ex.: o vaso do potted fern deve continuar com a cor normal).

## Contexto

Parte 5 de 5 da feature `improve-season-world-colors`. Depende de `feat/season-color-hue-model` (base deste PR).
