### PR TITLE
feat: manter a mensagem de virada de dia mais tempo na tela

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/SeasonsHudOverlay.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonsHudOverlay.java
@@ -13,6 +13,18 @@ import net.minecraft.world.World;
 public class SeasonsHudOverlay implements HudRenderCallback {
   private static final int SEASON_OVERLAY_SCALE = 16;
 
+  /** Length of a Minecraft day in ticks. */
+  private static final int DAY_DURATION = 24000;
+
+  /** How long the day change message stays on screen, in ticks. 160 ticks is 8 seconds. */
+  private static final int MESSAGE_DURATION = 160;
+
+  /** Ticks spent fading in at the start and fading out at the end. */
+  private static final int MESSAGE_FADE_DURATION = 20;
+
+  private static final int MIN_TEXT_ALPHA = 0x20;
+  private static final int MAX_TEXT_ALPHA = 0xFF;
+
   @Override
   public void onHudRender(DrawContext drawContext, float tickDelta) {
     MinecraftClient client = MinecraftClient.getInstance();
@@ -101,24 +113,30 @@ public class SeasonsHudOverlay implements HudRenderCallback {
   }
 
   private boolean isNewDay(long dayTime) {
-    long calc = dayTime % 24000;
+    long tickOfDay = dayTime % DAY_DURATION;
 
-    return calc >= 0 && calc <= 48;
+    return tickOfDay >= 0 && tickOfDay <= MESSAGE_DURATION;
   }
 
+  /**
+   * Alpha ramp for the day change message: fade in, hold at full opacity, fade out.
+   *
+   * <p>The alpha floor is deliberate. TextRenderer treats a colour whose alpha is below 0x04 as
+   * "no alpha given" and forces it to fully opaque, so fading all the way to zero would flash the
+   * text at full brightness on the first and last tick.
+   */
   public int getColor(long dayTime) {
-    return switch ((int) (dayTime % 24000)) {
-      case 0, 1, 2, 46, 47, 48 -> 0x20FFFFFF;
-      case 3, 4, 5, 43, 44, 45 -> 0x40FFFFFF;
-      case 6, 7, 8, 40, 41, 42 -> 0x60FFFFFF;
-      case 9, 10, 11, 37, 38, 39 -> 0x80FFFFFF;
-      case 12, 13, 14, 34, 35, 36 -> 0xA0FFFFFF;
-      case 15, 16, 17, 31, 32, 33 -> 0xC0FFFFFF;
-      case 18, 19, 20, 28, 29, 30 -> 0xD0FFFFFF;
-      case 21, 22, 26, 27 -> 0xE0FFFFFF;
-      case 23, 24, 25 -> 0xF0FFFFFF;
+    int tickOfDay = (int) (dayTime % DAY_DURATION);
 
-      default -> 0x000000;
-    };
+    if (tickOfDay < 0 || tickOfDay > MESSAGE_DURATION) {
+      return 0;
+    }
+
+    int ticksFromEdge = Math.min(tickOfDay, MESSAGE_DURATION - tickOfDay);
+    float fade = Math.min(1.0f, (float) ticksFromEdge / MESSAGE_FADE_DURATION);
+
+    int alpha = MIN_TEXT_ALPHA + Math.round((MAX_TEXT_ALPHA - MIN_TEXT_ALPHA) * fade);
+
+    return (alpha << 24) | 0xFFFFFF;
   }
 }


### PR DESCRIPTION
## Descrição

A mensagem de virada de dia durava 48 ticks (2.4 segundos), e o ramp de alpha era um triângulo puro: chegava em opacidade máxima só nos ticks 23 a 25 e já começava a sumir. Tempo insuficiente para ler algo como `Day 1 of January, Year 1` mais a linha de season ou holiday embaixo.

Agora dura 160 ticks (8 segundos), com 1s de fade in, 6s parada em opacidade total e 1s de fade out.

```
alpha
0xFF |    ________________
     |   /                \
     |  /                  \
0x20 |_/                    \_
     0  20      140        160 ticks
        \__/    \________/  \__/
        fade      hold      fade
```

## Alterações

- `MESSAGE_DURATION` (160 ticks) e `MESSAGE_FADE_DURATION` (20 ticks) como constantes nomeadas. Ajustar a duração agora é mudar um número, não reescrever uma tabela.
- `DAY_DURATION` vira constante em vez do `24000` mágico repetido em dois métodos.
- O `switch` de 48 casos do `getColor` vira um ramp calculado.
- `isNewDay` passa a usar a mesma constante de duração, então os dois métodos não podem mais sair de sincronia.

## Detalhe que vale saber

O piso de alpha em `0x20` foi mantido de propósito, herdado da tabela antiga. O `TextRenderer` trata cor com alpha abaixo de `0x04` como "alpha não informado" e força opacidade total — então fade até zero causaria um flash da mensagem em brilho máximo no primeiro e no último tick.

## Como testar

1. Entrar no mundo e esperar a virada do dia (tick 0 do dia).
2. Confirmar que a mensagem aparece suave, fica legível parada por vários segundos e some suave. Total de ~8 segundos.
3. Conferir em um dia de holiday (25/12 ou 28/10) que as duas linhas ficam visíveis pelo mesmo tempo.
4. Conferir na virada de season (dia 1 de janeiro, abril, julho, outubro) que a mensagem de season acompanha o mesmo fade.
5. Confirmar que não há flash de brilho no primeiro nem no último tick da mensagem.

## Contexto

Parte 6 de 6 da feature `improve-season-world-colors`. Depende de `feat/expand-season-tinted-blocks` (base deste PR).

O arquivo `SeasonsHudOverlay` não é tocado por nenhum PR anterior da stack, então este PR não tem conflito com os demais.
