### PR TITLE
feat: modelo de densidade de névoa por bioma, caverna e season

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
+++ b/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools;
 
 import net.abakath.rpg4fools.client.ClientModMessages;
 import net.abakath.rpg4fools.client.particle.MistParticle;
+import net.abakath.rpg4fools.client.particle.MistSpawner;
 import net.abakath.rpg4fools.client.SeasonColorProviders;
 import net.abakath.rpg4fools.client.SeasonsHudOverlay;
 import net.abakath.rpg4fools.init.ModParticles;
@@ -18,5 +19,6 @@ public class RPG4FoolsClient implements ClientModInitializer {
     SeasonColorProviders.register();
 
     ParticleFactoryRegistry.getInstance().register(ModParticles.MIST, MistParticle.Factory::new);
+    MistSpawner.register();
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/client/AtmosphereTint.java
+++ b/src/main/java/net/abakath/rpg4fools/client/AtmosphereTint.java
@@ -24,18 +24,18 @@ import net.fabricmc.api.Environment;
  */
 @Environment(EnvType.CLIENT)
 public enum AtmosphereTint {
-  EARLY_SPRING(SubSeason.EARLY_SPRING, 2.0f, 0.90f, 1.02f, 0.92f, 0.88f),
-  MID_SPRING(SubSeason.MID_SPRING, 0.0f, 0.98f, 1.04f, 1.00f, 1.00f),
-  LATE_SPRING(SubSeason.LATE_SPRING, -2.0f, 1.02f, 1.04f, 1.03f, 1.04f),
-  EARLY_SUMMER(SubSeason.EARLY_SUMMER, -4.0f, 1.06f, 1.03f, 1.04f, 1.05f),
-  MID_SUMMER(SubSeason.MID_SUMMER, -6.0f, 1.10f, 1.02f, 1.05f, 1.06f),
-  LATE_SUMMER(SubSeason.LATE_SUMMER, -8.0f, 1.06f, 1.00f, 1.02f, 1.02f),
-  EARLY_AUTUMN(SubSeason.EARLY_AUTUMN, -12.0f, 1.00f, 0.98f, 0.95f, 0.88f),
-  MID_AUTUMN(SubSeason.MID_AUTUMN, -16.0f, 0.94f, 0.95f, 0.88f, 0.72f),
-  LATE_AUTUMN(SubSeason.LATE_AUTUMN, -14.0f, 0.82f, 0.92f, 0.78f, 0.55f),
-  EARLY_WINTER(SubSeason.EARLY_WINTER, -8.0f, 0.66f, 0.92f, 0.68f, 0.42f),
-  MID_WINTER(SubSeason.MID_WINTER, -2.0f, 0.55f, 0.95f, 0.60f, 0.35f),
-  LATE_WINTER(SubSeason.LATE_WINTER, 0.0f, 0.70f, 0.98f, 0.75f, 0.50f);
+  EARLY_SPRING(SubSeason.EARLY_SPRING, 2.0f, 0.90f, 1.02f, 0.92f, 0.88f, 0.10f),
+  MID_SPRING(SubSeason.MID_SPRING, 0.0f, 0.98f, 1.04f, 1.00f, 1.00f, 0.02f),
+  LATE_SPRING(SubSeason.LATE_SPRING, -2.0f, 1.02f, 1.04f, 1.03f, 1.04f, 0.00f),
+  EARLY_SUMMER(SubSeason.EARLY_SUMMER, -4.0f, 1.06f, 1.03f, 1.04f, 1.05f, 0.00f),
+  MID_SUMMER(SubSeason.MID_SUMMER, -6.0f, 1.10f, 1.02f, 1.05f, 1.06f, 0.00f),
+  LATE_SUMMER(SubSeason.LATE_SUMMER, -8.0f, 1.06f, 1.00f, 1.02f, 1.02f, 0.00f),
+  EARLY_AUTUMN(SubSeason.EARLY_AUTUMN, -12.0f, 1.00f, 0.98f, 0.95f, 0.88f, 0.05f),
+  MID_AUTUMN(SubSeason.MID_AUTUMN, -16.0f, 0.94f, 0.95f, 0.88f, 0.72f, 0.15f),
+  LATE_AUTUMN(SubSeason.LATE_AUTUMN, -14.0f, 0.82f, 0.92f, 0.78f, 0.55f, 0.28f),
+  EARLY_WINTER(SubSeason.EARLY_WINTER, -8.0f, 0.66f, 0.92f, 0.68f, 0.42f, 0.40f),
+  MID_WINTER(SubSeason.MID_WINTER, -2.0f, 0.55f, 0.95f, 0.60f, 0.35f, 0.45f),
+  LATE_WINTER(SubSeason.LATE_WINTER, 0.0f, 0.70f, 0.98f, 0.75f, 0.50f, 0.32f);
 
   private static final float DEGREES_IN_CIRCLE = 360.0f;
 
@@ -45,19 +45,22 @@ public enum AtmosphereTint {
   private final float brightnessFactor;
   private final float fogDistanceFactor;
   private final float fogStartFactor;
+  private final float mistBoost;
 
   AtmosphereTint(SubSeason subSeason,
                  float hueShiftDegrees,
                  float saturationFactor,
                  float brightnessFactor,
                  float fogDistanceFactor,
-                 float fogStartFactor) {
+                 float fogStartFactor,
+                 float mistBoost) {
     this.subSeason = subSeason;
     this.hueShiftDegrees = hueShiftDegrees;
     this.saturationFactor = saturationFactor;
     this.brightnessFactor = brightnessFactor;
     this.fogDistanceFactor = fogDistanceFactor;
     this.fogStartFactor = fogStartFactor;
+    this.mistBoost = mistBoost;
   }
 
   public SubSeason getSubSeason() {
@@ -82,6 +85,15 @@ public enum AtmosphereTint {
 
   public float getFogStartFactor() {
     return fogStartFactor;
+  }
+
+  /**
+   * Mist this sub season adds on top of a family's baseline, rather than multiplies. That is what
+   * lets an open biome sitting at zero baseline still get a thin cold haze in winter while staying
+   * completely clear in summer.
+   */
+  public float getMistBoost() {
+    return mistBoost;
   }
 
   public static AtmosphereTint of(SubSeason subSeason) {

--- a/src/main/java/net/abakath/rpg4fools/client/BiomeAtmosphere.java
+++ b/src/main/java/net/abakath/rpg4fools/client/BiomeAtmosphere.java
@@ -24,21 +24,21 @@ import java.util.Map;
  */
 @Environment(EnvType.CLIENT)
 public enum BiomeAtmosphere {
-  SWAMP(ConventionalBiomeTags.IS_SWAMP, 0x5F7A22, 0.55f, 0.60f, 0.20f),
-  SNOWY(ConventionalBiomeTags.IS_SNOWY, 0xC8DCFF, 0.45f, 0.75f, 0.90f),
-  TAIGA(ConventionalBiomeTags.IS_TAIGA, 0xA8C0D0, 0.35f, 0.85f, 1.00f),
-  JUNGLE(ConventionalBiomeTags.IS_JUNGLE, 0x4E8C3A, 0.40f, 0.70f, 0.35f),
-  BADLANDS(ConventionalBiomeTags.IS_BADLANDS, 0xC8873F, 0.40f, 0.85f, 0.15f),
-  DESERT(ConventionalBiomeTags.IS_DESERT, 0xE0C88A, 0.30f, 1.00f, 0.10f),
-  SAVANNA(ConventionalBiomeTags.IS_SAVANNA, 0xC4B87A, 0.25f, 0.95f, 0.25f),
-  MOUNTAIN(ConventionalBiomeTags.IS_MOUNTAIN, 0xD0DCE8, 0.30f, 0.90f, 0.80f),
-  FOREST(ConventionalBiomeTags.IS_FOREST, 0x8FA870, 0.20f, 0.90f, 0.85f),
+  SWAMP(ConventionalBiomeTags.IS_SWAMP, 0x5F7A22, 0.55f, 0.60f, 0.20f, 0.90f),
+  SNOWY(ConventionalBiomeTags.IS_SNOWY, 0xC8DCFF, 0.45f, 0.75f, 0.90f, 0.85f),
+  TAIGA(ConventionalBiomeTags.IS_TAIGA, 0xA8C0D0, 0.35f, 0.85f, 1.00f, 0.50f),
+  JUNGLE(ConventionalBiomeTags.IS_JUNGLE, 0x4E8C3A, 0.40f, 0.70f, 0.35f, 0.60f),
+  BADLANDS(ConventionalBiomeTags.IS_BADLANDS, 0xC8873F, 0.40f, 0.85f, 0.15f, 0.15f),
+  DESERT(ConventionalBiomeTags.IS_DESERT, 0xE0C88A, 0.30f, 1.00f, 0.10f, 0.00f),
+  SAVANNA(ConventionalBiomeTags.IS_SAVANNA, 0xC4B87A, 0.25f, 0.95f, 0.25f, 0.00f),
+  MOUNTAIN(ConventionalBiomeTags.IS_MOUNTAIN, 0xD0DCE8, 0.30f, 0.90f, 0.80f, 0.30f),
+  FOREST(ConventionalBiomeTags.IS_FOREST, 0x8FA870, 0.20f, 0.90f, 0.85f, 0.25f),
 
   /**
    * Fallback for anything untagged, including plains. Blend of zero means the vanilla fog colour is
    * left exactly as it is, so an unrecognised biome still behaves like it does today.
    */
-  DEFAULT(null, 0xFFFFFF, 0.00f, 1.00f, 1.00f);
+  DEFAULT(null, 0xFFFFFF, 0.00f, 1.00f, 1.00f, 0.00f);
 
   /**
    * Memoises the family per biome entry. Tag matching walks every family in the worst case, and the
@@ -54,17 +54,20 @@ public enum BiomeAtmosphere {
   private final float colorBlend;
   private final float baseDensity;
   private final float seasonSensitivity;
+  private final float mistDensity;
 
   BiomeAtmosphere(TagKey<Biome> tag,
                   int tintColor,
                   float colorBlend,
                   float baseDensity,
-                  float seasonSensitivity) {
+                  float seasonSensitivity,
+                  float mistDensity) {
     this.tag = tag;
     this.tintColor = tintColor;
     this.colorBlend = colorBlend;
     this.baseDensity = baseDensity;
     this.seasonSensitivity = seasonSensitivity;
+    this.mistDensity = mistDensity;
   }
 
   /** Colour the vanilla fog colour is pulled towards. */
@@ -85,6 +88,15 @@ public enum BiomeAtmosphere {
   /** How strongly the season is allowed to move this family's density, from 0 to 1. */
   public float getSeasonSensitivity() {
     return seasonSensitivity;
+  }
+
+  /**
+   * How much suspended mist this family carries, from 0 to 1, before the season and the weather
+   * have their say. Open biomes sit at 0 on purpose: plains should only ever get mist because the
+   * season put it there, never as a baseline.
+   */
+  public float getMistDensity() {
+    return mistDensity;
   }
 
   public static BiomeAtmosphere of(RegistryEntry<Biome> entry) {

--- a/src/main/java/net/abakath/rpg4fools/client/CaveAtmosphere.java
+++ b/src/main/java/net/abakath/rpg4fools/client/CaveAtmosphere.java
@@ -19,21 +19,23 @@ import net.minecraft.world.biome.BiomeKeys;
  */
 @Environment(EnvType.CLIENT)
 public enum CaveAtmosphere {
-  DRIPSTONE(0x6B5B4A, 0.55f, 0.62f, 0.50f),
-  LUSH(0x4A7A3A, 0.50f, 0.68f, 0.55f),
-  DEEP_DARK(0x0E1418, 0.75f, 0.42f, 0.30f),
-  GENERIC(0x2A2E36, 0.45f, 0.72f, 0.60f);
+  DRIPSTONE(0x6B5B4A, 0.55f, 0.62f, 0.50f, 0.55f),
+  LUSH(0x4A7A3A, 0.50f, 0.68f, 0.55f, 0.65f),
+  DEEP_DARK(0x0E1418, 0.75f, 0.42f, 0.30f, 0.80f),
+  GENERIC(0x2A2E36, 0.45f, 0.72f, 0.60f, 0.45f);
 
   private final int tintColor;
   private final float colorBlend;
   private final float density;
   private final float startFactor;
+  private final float mistDensity;
 
-  CaveAtmosphere(int tintColor, float colorBlend, float density, float startFactor) {
+  CaveAtmosphere(int tintColor, float colorBlend, float density, float startFactor, float mistDensity) {
     this.tintColor = tintColor;
     this.colorBlend = colorBlend;
     this.density = density;
     this.startFactor = startFactor;
+    this.mistDensity = mistDensity;
   }
 
   public int getTintColor() {
@@ -51,6 +53,11 @@ public enum CaveAtmosphere {
   /** Factor on the vanilla fog start. Lower brings the mist right up to the player. */
   public float getStartFactor() {
     return startFactor;
+  }
+
+  /** How much suspended mist this cave carries. Not affected by the season. */
+  public float getMistDensity() {
+    return mistDensity;
   }
 
   public static CaveAtmosphere of(RegistryEntry<Biome> entry) {

--- a/src/main/java/net/abakath/rpg4fools/client/ResolvedAtmosphere.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ResolvedAtmosphere.java
@@ -19,6 +19,7 @@ import net.minecraft.util.math.Vec3d;
  * @param fogStartFactor     factor on the vanilla fog start, already compensated for the distance
  *                           factor the density hook applies
  * @param seasonStrength     how strongly the season applies here, used for the colour grade
+ * @param mistDensity        how much suspended mist to draw here, 0 to 1
  */
 @Environment(EnvType.CLIENT)
 public record ResolvedAtmosphere(
@@ -26,7 +27,8 @@ public record ResolvedAtmosphere(
         float colorBlend,
         float fogDistanceFactor,
         float fogStartFactor,
-        float seasonStrength
+        float seasonStrength,
+        float mistDensity
 ) {
   /**
    * The sky takes the biome tint at a reduced weight. A swamp should feel humid and green near the

--- a/src/main/java/net/abakath/rpg4fools/client/SeasonAtmosphere.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonAtmosphere.java
@@ -77,7 +77,7 @@ public final class SeasonAtmosphere {
    *
    * @param effectiveStrength family season sensitivity multiplied by the temperature curve
    */
-  private record BiomeAggregate(int tintColor, float colorBlend, float baseDensity, float effectiveStrength) {
+  private record BiomeAggregate(int tintColor, float colorBlend, float baseDensity, float effectiveStrength, float mistDensity) {
   }
 
   /**
@@ -106,7 +106,8 @@ public final class SeasonAtmosphere {
               aggregate.colorBlend(),
               fogDistanceFactor,
               fogStartFactor,
-              aggregate.effectiveStrength()
+              aggregate.effectiveStrength(),
+              surfaceMistDensity(aggregate)
       );
     }
 
@@ -117,8 +118,26 @@ public final class SeasonAtmosphere {
             lerp(aggregate.colorBlend(), cave.getColorBlend(), caveFactor),
             lerp(fogDistanceFactor, cave.getDensity(), caveFactor),
             lerp(fogStartFactor, cave.getStartFactor(), caveFactor),
-            lerp(aggregate.effectiveStrength(), 0.0f, caveFactor)
+            lerp(aggregate.effectiveStrength(), 0.0f, caveFactor),
+            lerp(surfaceMistDensity(aggregate), cave.getMistDensity(), caveFactor)
     );
+  }
+
+  /**
+   * Mist at the surface: the family baseline plus what the season adds.
+   *
+   * <p>The season adds rather than multiplies on purpose. An open biome sits at a zero baseline, so
+   * multiplying would leave it clear all year. Adding is what gives plains a thin cold haze in
+   * winter while keeping it completely clear in summer.
+   */
+  private static float surfaceMistDensity(BiomeAggregate aggregate) {
+    float t = ClientSeasonState.getProgress();
+    AtmosphereTint current = AtmosphereTint.of(ClientSeasonState.getSubSeason());
+    AtmosphereTint next = current.next();
+
+    float boost = lerp(current.getMistBoost(), next.getMistBoost(), t);
+
+    return ColorMath.clamp01(aggregate.mistDensity() + boost * aggregate.effectiveStrength());
   }
 
   /**
@@ -151,7 +170,7 @@ public final class SeasonAtmosphere {
 
   private static BiomeAggregate aggregateFor(WorldView world, BlockPos pos) {
     if (world == null || pos == null) {
-      return new BiomeAggregate(0xFFFFFF, 0.0f, 1.0f, 1.0f);
+      return new BiomeAggregate(0xFFFFFF, 0.0f, 1.0f, 1.0f, 0.0f);
     }
 
     long cellKey = cacheCellKey(pos);
@@ -181,6 +200,7 @@ public final class SeasonAtmosphere {
     float totalBlend = 0.0f;
     float totalBaseDensity = 0.0f;
     float totalStrength = 0.0f;
+    float totalMist = 0.0f;
 
     for (int offsetX : SAMPLE_OFFSETS) {
       for (int offsetZ : SAMPLE_OFFSETS) {
@@ -197,6 +217,7 @@ public final class SeasonAtmosphere {
         totalBlend += family.getColorBlend();
         totalBaseDensity += family.getBaseDensity();
         totalStrength += family.getSeasonSensitivity() * strengthForTemperature(entry.value().getTemperature());
+        totalMist += family.getMistDensity();
       }
     }
 
@@ -210,7 +231,8 @@ public final class SeasonAtmosphere {
             tintColor,
             totalBlend / samples,
             totalBaseDensity / samples,
-            totalStrength / samples
+            totalStrength / samples,
+            totalMist / samples
     );
   }
 

--- a/src/main/java/net/abakath/rpg4fools/client/WeatherMist.java
+++ b/src/main/java/net/abakath/rpg4fools/client/WeatherMist.java
@@ -1,0 +1,76 @@
+package net.abakath.rpg4fools.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+
+/**
+ * How much the current weather thickens the mist.
+ *
+ * <p>Snow counts for more than rain. Snow falling through already freezing air is the case the mod
+ * is trying to sell, so a snowy biome mid blizzard is the densest the mist ever gets.
+ *
+ * <p>Weather is read from the client world, which tracks rain and thunder gradients rather than a
+ * boolean, so the mist thickens as the storm rolls in instead of switching on.
+ */
+@Environment(EnvType.CLIENT)
+public final class WeatherMist {
+  /** Multiplier at full rain, for biomes where the precipitation falls as water. */
+  private static final float RAIN_MULTIPLIER = 1.30f;
+
+  /** Multiplier at full snowfall. Higher than rain: this is the effect worth selling. */
+  private static final float SNOW_MULTIPLIER = 1.60f;
+
+  /** Extra on top during a thunderstorm. */
+  private static final float THUNDER_MULTIPLIER = 1.15f;
+
+  private WeatherMist() {
+  }
+
+  /**
+   * Multiplier to apply to the mist density, 1 in clear weather.
+   *
+   * @param rainGradient    0 to 1, how far into rain or snow the sky is
+   * @param thunderGradient 0 to 1, how far into a thunderstorm
+   * @param snowing         whether precipitation falls as snow at this position
+   */
+  public static float multiplier(float rainGradient, float thunderGradient, boolean snowing) {
+    float peak = snowing ? SNOW_MULTIPLIER : RAIN_MULTIPLIER;
+
+    float weather = 1.0f + (peak - 1.0f) * ColorMath.clamp01(rainGradient);
+    float thunder = 1.0f + (THUNDER_MULTIPLIER - 1.0f) * ColorMath.clamp01(thunderGradient);
+
+    return weather * thunder;
+  }
+
+  /**
+   * Reads the weather at a position and returns the mist multiplier for it.
+   *
+   * <p>Precipitation type comes from the biome rather than from the world, since whether it snows
+   * is a property of where you are standing, not of the sky.
+   */
+  public static float multiplierAt(World world, BlockPos pos) {
+    if (world == null || pos == null) {
+      return 1.0f;
+    }
+
+    float rainGradient = world.getRainGradient(1.0f);
+
+    if (rainGradient <= 0.0f) {
+      return 1.0f;
+    }
+
+    // Weather cannot reach through a roof, so a cave or a house should not thicken. This also keeps
+    // the cave mist, which is meant to ignore the sky entirely, out of the weather path.
+    if (!world.isSkyVisible(pos)) {
+      return 1.0f;
+    }
+
+    Biome biome = world.getBiome(pos).value();
+    boolean snowing = biome.getPrecipitation(pos) == Biome.Precipitation.SNOW;
+
+    return multiplier(rainGradient, world.getThunderGradient(1.0f), snowing);
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools.client.particle;
 
 import net.abakath.rpg4fools.client.ResolvedAtmosphere;
 import net.abakath.rpg4fools.client.SeasonAtmosphere;
+import net.abakath.rpg4fools.client.WeatherMist;
 import net.abakath.rpg4fools.init.ModParticles;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -24,8 +25,16 @@ import net.minecraft.world.World;
  */
 @Environment(EnvType.CLIENT)
 public final class MistSpawner {
-  /** Puffs alive at full density. The real cost here is overdraw, so this is the number to tune. */
-  private static final int MAX_PARTICLES = 220;
+  /** Puffs alive at density 1. The real cost here is overdraw, so this is the number to tune. */
+  private static final int MAX_PARTICLES = 180;
+
+  /**
+   * Ceiling on density. Deliberately above 1 so weather has somewhere to go: several biomes already
+   * sit near 1 in winter, and clamping there would erase the difference between a cold biome and a
+   * cold biome mid snowfall, which is the effect worth having. Worst case population is therefore
+   * MAX_PARTICLES times this.
+   */
+  private static final float MAX_DENSITY = 1.5f;
 
   /**
    * Average puff lifetime in ticks, matching MistParticle. Population settles at spawn rate times
@@ -75,7 +84,7 @@ public final class MistSpawner {
     BlockPos cameraPos = player.getBlockPos();
     ResolvedAtmosphere atmosphere = SeasonAtmosphere.resolve(world, cameraPos);
 
-    float density = atmosphere.mistDensity();
+    float density = Math.min(MAX_DENSITY, atmosphere.mistDensity() * WeatherMist.multiplierAt(world, cameraPos));
     if (density < MIN_DENSITY) {
       return;
     }

--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -1,0 +1,148 @@
+package net.abakath.rpg4fools.client.particle;
+
+import net.abakath.rpg4fools.client.ResolvedAtmosphere;
+import net.abakath.rpg4fools.client.SeasonAtmosphere;
+import net.abakath.rpg4fools.init.ModParticles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.ParticlesMode;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
+
+/**
+ * Fills the air around the player with mist.
+ *
+ * <p>Keeps a target number of puffs alive rather than spawning at a fixed rate, so the density
+ * reads the same whether the player is standing still or sprinting. The target follows the
+ * atmosphere at the camera, which is what makes walking from plains into a swamp thicken the air.
+ */
+@Environment(EnvType.CLIENT)
+public final class MistSpawner {
+  /** Puffs alive at full density. The real cost here is overdraw, so this is the number to tune. */
+  private static final int MAX_PARTICLES = 220;
+
+  /**
+   * Average puff lifetime in ticks, matching MistParticle. Population settles at spawn rate times
+   * lifetime, so this is what turns a target population into a per tick rate.
+   */
+  private static final int AVERAGE_LIFETIME = 100;
+
+  /** Ceiling on spawns per tick, so a sudden density jump eases in instead of popping. */
+  private static final int MAX_SPAWNS_PER_TICK = 8;
+
+  /** Horizontal reach of the spawn volume, in blocks. */
+  private static final int SPAWN_RADIUS = 16;
+
+  /** Vertical reach of the spawn volume, in blocks. */
+  private static final int SPAWN_HEIGHT = 8;
+
+  /** Below this density nothing spawns at all, so clear biomes cost nothing. */
+  private static final float MIN_DENSITY = 0.02f;
+
+  private static final float BASE_ALPHA = 0.10f;
+  private static final float BASE_SCALE = 3.0f;
+
+  private MistSpawner() {
+  }
+
+  public static void register() {
+    ClientTickEvents.END_CLIENT_TICK.register(MistSpawner::onClientTick);
+  }
+
+  private static void onClientTick(MinecraftClient client) {
+    ClientWorld world = client.world;
+    PlayerEntity player = client.player;
+
+    if (world == null || player == null || client.isPaused()) {
+      return;
+    }
+
+    if (!world.getRegistryKey().equals(World.OVERWORLD)) {
+      return;
+    }
+
+    float quality = particleQuality(client);
+    if (quality <= 0.0f) {
+      return;
+    }
+
+    BlockPos cameraPos = player.getBlockPos();
+    ResolvedAtmosphere atmosphere = SeasonAtmosphere.resolve(world, cameraPos);
+
+    float density = atmosphere.mistDensity();
+    if (density < MIN_DENSITY) {
+      return;
+    }
+
+    // Population settles at rate times lifetime, so aiming for a target population is just a
+    // division. No need to track individual puffs, and it self corrects when some expire early
+    // after the player teleports or the density drops.
+    float target = MAX_PARTICLES * density * quality;
+    float ratePerTick = target / AVERAGE_LIFETIME;
+
+    int spawns = Math.min(MAX_SPAWNS_PER_TICK, (int) ratePerTick);
+
+    // Spawn the fractional remainder probabilistically, so a rate below one per tick still works.
+    if (world.getRandom().nextFloat() < ratePerTick - (int) ratePerTick) {
+      spawns++;
+    }
+
+    for (int i = 0; i < spawns; i++) {
+      spawnPuff(client, world, cameraPos, atmosphere, density);
+    }
+  }
+
+  private static void spawnPuff(MinecraftClient client,
+                                ClientWorld world,
+                                BlockPos cameraPos,
+                                ResolvedAtmosphere atmosphere,
+                                float density) {
+    Random random = world.getRandom();
+
+    double x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+    double y = cameraPos.getY() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_HEIGHT;
+    double z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+
+    BlockPos spawnPos = BlockPos.ofFloored(x, y, z);
+
+    if (!world.getBlockState(spawnPos).isAir()) {
+      return;
+    }
+
+    double driftX = (random.nextDouble() - 0.5) * 0.006;
+    double driftY = (random.nextDouble() - 0.5) * 0.002;
+    double driftZ = (random.nextDouble() - 0.5) * 0.006;
+
+    Particle particle = client.particleManager.addParticle(
+            ModParticles.MIST, x, y, z, driftX, driftY, driftZ
+    );
+
+    if (!(particle instanceof MistParticle mist)) {
+      return;
+    }
+
+    mist.setMistColor(atmosphere.tintColor());
+    mist.setPeakAlpha(BASE_ALPHA * (0.6f + 0.4f * density));
+    mist.setMistScale(BASE_SCALE * (0.7f + 0.6f * (float) random.nextDouble()));
+  }
+
+  /**
+   * Scales density by the game's own particle setting, so a player on a weak machine already has
+   * the control without the mod inventing a config system.
+   */
+  private static float particleQuality(MinecraftClient client) {
+    ParticlesMode mode = client.options.getParticles().getValue();
+
+    return switch (mode) {
+      case ALL -> 1.0f;
+      case DECREASED -> 0.5f;
+      case MINIMAL -> 0.0f;
+    };
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -26,7 +26,7 @@ import net.minecraft.world.World;
 @Environment(EnvType.CLIENT)
 public final class MistSpawner {
   /** Puffs alive at density 1. The real cost here is overdraw, so this is the number to tune. */
-  private static final int MAX_PARTICLES = 180;
+  private static final int MAX_PARTICLES = 260;
 
   /**
    * Ceiling on density. Deliberately above 1 so weather has somewhere to go: several biomes already
@@ -48,14 +48,24 @@ public final class MistSpawner {
   /** Horizontal reach of the spawn volume, in blocks. */
   private static final int SPAWN_RADIUS = 16;
 
-  /** Vertical reach of the spawn volume, in blocks. */
-  private static final int SPAWN_HEIGHT = 8;
+  /** How far below the player the spawn volume reaches. Kept short: below is usually ground. */
+  private static final int SPAWN_BELOW = 2;
+
+  /** How far above the player the spawn volume reaches. */
+  private static final int SPAWN_ABOVE = 10;
+
+  /**
+   * Placement attempts per puff before giving up. A rejected position used to waste the whole
+   * spawn, which cost roughly two thirds of the intended population in a swamp, where much of the
+   * volume is water or ground.
+   */
+  private static final int MAX_PLACEMENT_TRIES = 5;
 
   /** Below this density nothing spawns at all, so clear biomes cost nothing. */
   private static final float MIN_DENSITY = 0.02f;
 
-  private static final float BASE_ALPHA = 0.10f;
-  private static final float BASE_SCALE = 3.0f;
+  private static final float BASE_ALPHA = 0.45f;
+  private static final float BASE_SCALE = 4.5f;
 
   private MistSpawner() {
   }
@@ -114,13 +124,25 @@ public final class MistSpawner {
                                 float density) {
     Random random = world.getRandom();
 
-    double x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
-    double y = cameraPos.getY() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_HEIGHT;
-    double z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    boolean placed = false;
 
-    BlockPos spawnPos = BlockPos.ofFloored(x, y, z);
+    // Retry instead of discarding the spawn. A single attempt threw away most of the intended
+    // population wherever the air is not clear, which is exactly the biomes the mist is for.
+    for (int attempt = 0; attempt < MAX_PLACEMENT_TRIES; attempt++) {
+      x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+      y = cameraPos.getY() + 0.5 - SPAWN_BELOW + random.nextDouble() * (SPAWN_BELOW + SPAWN_ABOVE);
+      z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
 
-    if (!world.getBlockState(spawnPos).isAir()) {
+      if (world.getBlockState(BlockPos.ofFloored(x, y, z)).isAir()) {
+        placed = true;
+        break;
+      }
+    }
+
+    if (!placed) {
       return;
     }
 


### PR DESCRIPTION
## Descrição

Estende os dados de atmosfera com **quanta névoa suspensa** existe numa posição. Nada desenha ainda — o spawner vem no PR 3.

## A decisão central: season **soma**, não multiplica

Esse é o ponto todo. Bioma aberto tem baseline zero, então multiplicar deixaria planície limpa o ano inteiro por mais frio que fizesse. Somar dá à planície a névoa fria fina no inverno e mantém ela completamente limpa no verão — que é exatamente o que você pediu.

```
mist = clamp01( baseline_da_familia + mistBoost_da_subseason * effectiveStrength )
```

## Densidade resultante

| bioma | verão | inverno | |
|---|---:|---:|---|
| swamp | 0.90 | 0.97 | denso em qualquer mês |
| snowy | 0.85 | 1.00 | |
| taiga | 0.50 | 0.95 | |
| forest | 0.25 | 0.59 | |
| plains | 0.00 | 0.35 | só pela season |
| desert | 0.00 | 0.00 | nunca |

Deserto fica em zero porque a curva de temperatura zera o `effectiveStrength` dele — o boost de inverno multiplicado por zero continua zero. Não precisou de caso especial.

## Alterações

- `mistDensity` novo no `BiomeAtmosphere` e no `CaveAtmosphere`.
- `mistBoost` novo no `AtmosphereTint`, por sub season. Zero no verão, `0.45` no mid winter.
- `mistDensity` novo no `ResolvedAtmosphere`, propagado pelo blend 5x5 e pelo `resolve`.

## Cavernas

Cavernas carregam densidade própria e **ignoram a season** — o calendário não deve alcançar o subterrâneo. Deep dark é a mais fechada das quatro (`0.80`).

## Como testar

Não muda nada visualmente ainda.

1. `./gradlew build` passa.
2. Revisar a tabela acima contra `surfaceMistDensity` no `SeasonAtmosphere`.
3. Conferir se os baselines por família fazem sentido — são o principal candidato a ajuste depois que der pra ver no jogo.

## Contexto

Parte 2 de 4 da feature `add-biome-mist`. Depende de `feat/mist-particle-type` (base deste PR).
