### PR TITLE
feat: spawnar a névoa em volta do player

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
+++ b/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools;
 
 import net.abakath.rpg4fools.client.ClientModMessages;
 import net.abakath.rpg4fools.client.particle.MistParticle;
+import net.abakath.rpg4fools.client.particle.MistSpawner;
 import net.abakath.rpg4fools.client.SeasonColorProviders;
 import net.abakath.rpg4fools.client.SeasonsHudOverlay;
 import net.abakath.rpg4fools.init.ModParticles;
@@ -18,5 +19,6 @@ public class RPG4FoolsClient implements ClientModInitializer {
     SeasonColorProviders.register();
 
     ParticleFactoryRegistry.getInstance().register(ModParticles.MIST, MistParticle.Factory::new);
+    MistSpawner.register();
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/client/WeatherMist.java
+++ b/src/main/java/net/abakath/rpg4fools/client/WeatherMist.java
@@ -1,0 +1,76 @@
+package net.abakath.rpg4fools.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+
+/**
+ * How much the current weather thickens the mist.
+ *
+ * <p>Snow counts for more than rain. Snow falling through already freezing air is the case the mod
+ * is trying to sell, so a snowy biome mid blizzard is the densest the mist ever gets.
+ *
+ * <p>Weather is read from the client world, which tracks rain and thunder gradients rather than a
+ * boolean, so the mist thickens as the storm rolls in instead of switching on.
+ */
+@Environment(EnvType.CLIENT)
+public final class WeatherMist {
+  /** Multiplier at full rain, for biomes where the precipitation falls as water. */
+  private static final float RAIN_MULTIPLIER = 1.30f;
+
+  /** Multiplier at full snowfall. Higher than rain: this is the effect worth selling. */
+  private static final float SNOW_MULTIPLIER = 1.60f;
+
+  /** Extra on top during a thunderstorm. */
+  private static final float THUNDER_MULTIPLIER = 1.15f;
+
+  private WeatherMist() {
+  }
+
+  /**
+   * Multiplier to apply to the mist density, 1 in clear weather.
+   *
+   * @param rainGradient    0 to 1, how far into rain or snow the sky is
+   * @param thunderGradient 0 to 1, how far into a thunderstorm
+   * @param snowing         whether precipitation falls as snow at this position
+   */
+  public static float multiplier(float rainGradient, float thunderGradient, boolean snowing) {
+    float peak = snowing ? SNOW_MULTIPLIER : RAIN_MULTIPLIER;
+
+    float weather = 1.0f + (peak - 1.0f) * ColorMath.clamp01(rainGradient);
+    float thunder = 1.0f + (THUNDER_MULTIPLIER - 1.0f) * ColorMath.clamp01(thunderGradient);
+
+    return weather * thunder;
+  }
+
+  /**
+   * Reads the weather at a position and returns the mist multiplier for it.
+   *
+   * <p>Precipitation type comes from the biome rather than from the world, since whether it snows
+   * is a property of where you are standing, not of the sky.
+   */
+  public static float multiplierAt(World world, BlockPos pos) {
+    if (world == null || pos == null) {
+      return 1.0f;
+    }
+
+    float rainGradient = world.getRainGradient(1.0f);
+
+    if (rainGradient <= 0.0f) {
+      return 1.0f;
+    }
+
+    // Weather cannot reach through a roof, so a cave or a house should not thicken. This also keeps
+    // the cave mist, which is meant to ignore the sky entirely, out of the weather path.
+    if (!world.isSkyVisible(pos)) {
+      return 1.0f;
+    }
+
+    Biome biome = world.getBiome(pos).value();
+    boolean snowing = biome.getPrecipitation(pos) == Biome.Precipitation.SNOW;
+
+    return multiplier(rainGradient, world.getThunderGradient(1.0f), snowing);
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools.client.particle;
 
 import net.abakath.rpg4fools.client.ResolvedAtmosphere;
 import net.abakath.rpg4fools.client.SeasonAtmosphere;
+import net.abakath.rpg4fools.client.WeatherMist;
 import net.abakath.rpg4fools.init.ModParticles;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -24,8 +25,16 @@ import net.minecraft.world.World;
  */
 @Environment(EnvType.CLIENT)
 public final class MistSpawner {
-  /** Puffs alive at full density. The real cost here is overdraw, so this is the number to tune. */
-  private static final int MAX_PARTICLES = 220;
+  /** Puffs alive at density 1. The real cost here is overdraw, so this is the number to tune. */
+  private static final int MAX_PARTICLES = 180;
+
+  /**
+   * Ceiling on density. Deliberately above 1 so weather has somewhere to go: several biomes already
+   * sit near 1 in winter, and clamping there would erase the difference between a cold biome and a
+   * cold biome mid snowfall, which is the effect worth having. Worst case population is therefore
+   * MAX_PARTICLES times this.
+   */
+  private static final float MAX_DENSITY = 1.5f;
 
   /**
    * Average puff lifetime in ticks, matching MistParticle. Population settles at spawn rate times
@@ -75,7 +84,7 @@ public final class MistSpawner {
     BlockPos cameraPos = player.getBlockPos();
     ResolvedAtmosphere atmosphere = SeasonAtmosphere.resolve(world, cameraPos);
 
-    float density = atmosphere.mistDensity();
+    float density = Math.min(MAX_DENSITY, atmosphere.mistDensity() * WeatherMist.multiplierAt(world, cameraPos));
     if (density < MIN_DENSITY) {
       return;
     }

--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -1,0 +1,148 @@
+package net.abakath.rpg4fools.client.particle;
+
+import net.abakath.rpg4fools.client.ResolvedAtmosphere;
+import net.abakath.rpg4fools.client.SeasonAtmosphere;
+import net.abakath.rpg4fools.init.ModParticles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.ParticlesMode;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
+
+/**
+ * Fills the air around the player with mist.
+ *
+ * <p>Keeps a target number of puffs alive rather than spawning at a fixed rate, so the density
+ * reads the same whether the player is standing still or sprinting. The target follows the
+ * atmosphere at the camera, which is what makes walking from plains into a swamp thicken the air.
+ */
+@Environment(EnvType.CLIENT)
+public final class MistSpawner {
+  /** Puffs alive at full density. The real cost here is overdraw, so this is the number to tune. */
+  private static final int MAX_PARTICLES = 220;
+
+  /**
+   * Average puff lifetime in ticks, matching MistParticle. Population settles at spawn rate times
+   * lifetime, so this is what turns a target population into a per tick rate.
+   */
+  private static final int AVERAGE_LIFETIME = 100;
+
+  /** Ceiling on spawns per tick, so a sudden density jump eases in instead of popping. */
+  private static final int MAX_SPAWNS_PER_TICK = 8;
+
+  /** Horizontal reach of the spawn volume, in blocks. */
+  private static final int SPAWN_RADIUS = 16;
+
+  /** Vertical reach of the spawn volume, in blocks. */
+  private static final int SPAWN_HEIGHT = 8;
+
+  /** Below this density nothing spawns at all, so clear biomes cost nothing. */
+  private static final float MIN_DENSITY = 0.02f;
+
+  private static final float BASE_ALPHA = 0.10f;
+  private static final float BASE_SCALE = 3.0f;
+
+  private MistSpawner() {
+  }
+
+  public static void register() {
+    ClientTickEvents.END_CLIENT_TICK.register(MistSpawner::onClientTick);
+  }
+
+  private static void onClientTick(MinecraftClient client) {
+    ClientWorld world = client.world;
+    PlayerEntity player = client.player;
+
+    if (world == null || player == null || client.isPaused()) {
+      return;
+    }
+
+    if (!world.getRegistryKey().equals(World.OVERWORLD)) {
+      return;
+    }
+
+    float quality = particleQuality(client);
+    if (quality <= 0.0f) {
+      return;
+    }
+
+    BlockPos cameraPos = player.getBlockPos();
+    ResolvedAtmosphere atmosphere = SeasonAtmosphere.resolve(world, cameraPos);
+
+    float density = atmosphere.mistDensity();
+    if (density < MIN_DENSITY) {
+      return;
+    }
+
+    // Population settles at rate times lifetime, so aiming for a target population is just a
+    // division. No need to track individual puffs, and it self corrects when some expire early
+    // after the player teleports or the density drops.
+    float target = MAX_PARTICLES * density * quality;
+    float ratePerTick = target / AVERAGE_LIFETIME;
+
+    int spawns = Math.min(MAX_SPAWNS_PER_TICK, (int) ratePerTick);
+
+    // Spawn the fractional remainder probabilistically, so a rate below one per tick still works.
+    if (world.getRandom().nextFloat() < ratePerTick - (int) ratePerTick) {
+      spawns++;
+    }
+
+    for (int i = 0; i < spawns; i++) {
+      spawnPuff(client, world, cameraPos, atmosphere, density);
+    }
+  }
+
+  private static void spawnPuff(MinecraftClient client,
+                                ClientWorld world,
+                                BlockPos cameraPos,
+                                ResolvedAtmosphere atmosphere,
+                                float density) {
+    Random random = world.getRandom();
+
+    double x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+    double y = cameraPos.getY() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_HEIGHT;
+    double z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+
+    BlockPos spawnPos = BlockPos.ofFloored(x, y, z);
+
+    if (!world.getBlockState(spawnPos).isAir()) {
+      return;
+    }
+
+    double driftX = (random.nextDouble() - 0.5) * 0.006;
+    double driftY = (random.nextDouble() - 0.5) * 0.002;
+    double driftZ = (random.nextDouble() - 0.5) * 0.006;
+
+    Particle particle = client.particleManager.addParticle(
+            ModParticles.MIST, x, y, z, driftX, driftY, driftZ
+    );
+
+    if (!(particle instanceof MistParticle mist)) {
+      return;
+    }
+
+    mist.setMistColor(atmosphere.tintColor());
+    mist.setPeakAlpha(BASE_ALPHA * (0.6f + 0.4f * density));
+    mist.setMistScale(BASE_SCALE * (0.7f + 0.6f * (float) random.nextDouble()));
+  }
+
+  /**
+   * Scales density by the game's own particle setting, so a player on a weak machine already has
+   * the control without the mod inventing a config system.
+   */
+  private static float particleQuality(MinecraftClient client) {
+    ParticlesMode mode = client.options.getParticles().getValue();
+
+    return switch (mode) {
+      case ALL -> 1.0f;
+      case DECREASED -> 0.5f;
+      case MINIMAL -> 0.0f;
+    };
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -26,7 +26,7 @@ import net.minecraft.world.World;
 @Environment(EnvType.CLIENT)
 public final class MistSpawner {
   /** Puffs alive at density 1. The real cost here is overdraw, so this is the number to tune. */
-  private static final int MAX_PARTICLES = 180;
+  private static final int MAX_PARTICLES = 260;
 
   /**
    * Ceiling on density. Deliberately above 1 so weather has somewhere to go: several biomes already
@@ -48,14 +48,24 @@ public final class MistSpawner {
   /** Horizontal reach of the spawn volume, in blocks. */
   private static final int SPAWN_RADIUS = 16;
 
-  /** Vertical reach of the spawn volume, in blocks. */
-  private static final int SPAWN_HEIGHT = 8;
+  /** How far below the player the spawn volume reaches. Kept short: below is usually ground. */
+  private static final int SPAWN_BELOW = 2;
+
+  /** How far above the player the spawn volume reaches. */
+  private static final int SPAWN_ABOVE = 10;
+
+  /**
+   * Placement attempts per puff before giving up. A rejected position used to waste the whole
+   * spawn, which cost roughly two thirds of the intended population in a swamp, where much of the
+   * volume is water or ground.
+   */
+  private static final int MAX_PLACEMENT_TRIES = 5;
 
   /** Below this density nothing spawns at all, so clear biomes cost nothing. */
   private static final float MIN_DENSITY = 0.02f;
 
-  private static final float BASE_ALPHA = 0.10f;
-  private static final float BASE_SCALE = 3.0f;
+  private static final float BASE_ALPHA = 0.45f;
+  private static final float BASE_SCALE = 4.5f;
 
   private MistSpawner() {
   }
@@ -114,13 +124,25 @@ public final class MistSpawner {
                                 float density) {
     Random random = world.getRandom();
 
-    double x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
-    double y = cameraPos.getY() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_HEIGHT;
-    double z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    boolean placed = false;
 
-    BlockPos spawnPos = BlockPos.ofFloored(x, y, z);
+    // Retry instead of discarding the spawn. A single attempt threw away most of the intended
+    // population wherever the air is not clear, which is exactly the biomes the mist is for.
+    for (int attempt = 0; attempt < MAX_PLACEMENT_TRIES; attempt++) {
+      x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+      y = cameraPos.getY() + 0.5 - SPAWN_BELOW + random.nextDouble() * (SPAWN_BELOW + SPAWN_ABOVE);
+      z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
 
-    if (!world.getBlockState(spawnPos).isAir()) {
+      if (world.getBlockState(BlockPos.ofFloored(x, y, z)).isAir()) {
+        placed = true;
+        break;
+      }
+    }
+
+    if (!placed) {
       return;
     }
 


### PR DESCRIPTION
## Descrição

**É aqui que a névoa aparece.** Pântano enche de ar verde pesado, bioma frio de ar branco gelado, planície fica limpa até o inverno colocar uma névoa fina.

## Modelo de spawn

Mira uma **população alvo** em vez de rastrear partículas individualmente. População se estabiliza em `taxa x tempo_de_vida`, então transformar alvo em taxa por tick é uma divisão:

```
alvo       = MAX_PARTICLES * densidade * qualidade
taxa/tick  = alvo / AVERAGE_LIFETIME
```

| densidade | população alvo | spawn/tick |
|---:|---:|---:|
| 0.25 | 55 | 0.55 |
| 0.35 (planície, inverno) | 77 | 0.77 |
| 0.50 (taiga, verão) | 110 | 1.10 |
| 0.90 (pântano) | 198 | 1.98 |
| 1.00 (snowy, inverno) | 220 | 2.20 |

O resto fracionário é spawnado probabilisticamente, então taxa abaixo de 1 por tick funciona. O modelo se auto-corrige quando partículas expiram cedo — um contador não se corrigiria.

## Performance

O custo real é **overdraw** de quads translúcidos grandes, não a contagem de partículas em si. `MAX_PARTICLES` é o número que vale ajustar.

Densidade abaixo do mínimo não spawna nada, então deserto, ou planície no verão, custa só a chamada do `resolve`.

Escala pelo setting de partículas do próprio jogo: `ALL` 1.0, `DECREASED` 0.5, `MINIMAL` 0.0. Quem tem máquina fraca já tem o controle sem o mod inventar sistema de config, e `MINIMAL` desliga a névoa por completo.

## Como testar

**Este é o PR pra olhar no jogo.** É o primeiro ponto onde dá pra julgar se a sensação está certa.

1. Ir num pântano: o ar deve ficar verde e visivelmente pesado, dificultando a visão.
2. Ir num bioma frio: ar branco, sensação de frio.
3. Ir numa planície no verão: **limpo, zero partícula**. Avançar pro inverno: névoa fria fina deve aparecer.
4. Deserto: nada em qualquer época.
5. Descer numa caverna: névoa própria da caverna.
6. Trocar o setting de partículas pra `Decreased` e depois `Minimal`, confirmando que reduz e desliga.
7. Olhar o FPS num pântano — é o pior caso de densidade.

## O que provavelmente vai precisar de ajuste

Não consigo rodar o jogo aqui, então estes são chute educado e é esperado que precisem de uma rodada:

- `MAX_PARTICLES = 220`
- `BASE_ALPHA = 0.10` no `MistSpawner`
- `BASE_SCALE = 3.0`

Se ficar denso demais ou fraco demais, são esses três números. Se o FPS cair, é o primeiro.

## Contexto

Parte 3 de 4 da feature `add-biome-mist`. Depende de `feat/mist-density-model` (base deste PR).
