### PR TITLE
fix: tornar a névoa realmente visível

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
+++ b/src/main/java/net/abakath/rpg4fools/client/particle/MistSpawner.java
@@ -26,7 +26,7 @@ import net.minecraft.world.World;
 @Environment(EnvType.CLIENT)
 public final class MistSpawner {
   /** Puffs alive at density 1. The real cost here is overdraw, so this is the number to tune. */
-  private static final int MAX_PARTICLES = 180;
+  private static final int MAX_PARTICLES = 260;
 
   /**
    * Ceiling on density. Deliberately above 1 so weather has somewhere to go: several biomes already
@@ -48,14 +48,24 @@ public final class MistSpawner {
   /** Horizontal reach of the spawn volume, in blocks. */
   private static final int SPAWN_RADIUS = 16;
 
-  /** Vertical reach of the spawn volume, in blocks. */
-  private static final int SPAWN_HEIGHT = 8;
+  /** How far below the player the spawn volume reaches. Kept short: below is usually ground. */
+  private static final int SPAWN_BELOW = 2;
+
+  /** How far above the player the spawn volume reaches. */
+  private static final int SPAWN_ABOVE = 10;
+
+  /**
+   * Placement attempts per puff before giving up. A rejected position used to waste the whole
+   * spawn, which cost roughly two thirds of the intended population in a swamp, where much of the
+   * volume is water or ground.
+   */
+  private static final int MAX_PLACEMENT_TRIES = 5;
 
   /** Below this density nothing spawns at all, so clear biomes cost nothing. */
   private static final float MIN_DENSITY = 0.02f;
 
-  private static final float BASE_ALPHA = 0.10f;
-  private static final float BASE_SCALE = 3.0f;
+  private static final float BASE_ALPHA = 0.45f;
+  private static final float BASE_SCALE = 4.5f;
 
   private MistSpawner() {
   }
@@ -114,13 +124,25 @@ public final class MistSpawner {
                                 float density) {
     Random random = world.getRandom();
 
-    double x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
-    double y = cameraPos.getY() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_HEIGHT;
-    double z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    boolean placed = false;
 
-    BlockPos spawnPos = BlockPos.ofFloored(x, y, z);
+    // Retry instead of discarding the spawn. A single attempt threw away most of the intended
+    // population wherever the air is not clear, which is exactly the biomes the mist is for.
+    for (int attempt = 0; attempt < MAX_PLACEMENT_TRIES; attempt++) {
+      x = cameraPos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
+      y = cameraPos.getY() + 0.5 - SPAWN_BELOW + random.nextDouble() * (SPAWN_BELOW + SPAWN_ABOVE);
+      z = cameraPos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 2.0 * SPAWN_RADIUS;
 
-    if (!world.getBlockState(spawnPos).isAir()) {
+      if (world.getBlockState(BlockPos.ofFloored(x, y, z)).isAir()) {
+        placed = true;
+        break;
+      }
+    }
+
+    if (!placed) {
       return;
     }
 


### PR DESCRIPTION
## Descrição

A névoa spawnava mas era invisível. Diagnóstico numa sessão real apontou **duas causas separadas**, não uma.

Linha decisiva do log, num pântano ao longo de 40 ticks:

```
[mist] rawDensity=0,937 density=0,937 quality=1.0 |
       attempts=67 notAir=43 addNull=0 wrongType=0 spawned=24
```

## Causa 1 — colocações rejeitadas eram descartadas

A taxa estava **certa**: 67 tentativas / 40 ticks = 1,68 por tick, exatamente o alvo. Mas 43 das 67 caíam em chão ou água e eram jogadas fora sem nova tentativa. O pântano segurava ~60 puffs em vez dos 169 que mirava.

Ironia do bug: ele bate mais forte justamente nos biomas para os quais a névoa existe — pântano é cheio de água, caverna é cheia de pedra.

**Conserto:** até 5 tentativas de colocação por puff, e o volume de spawn passa a ser enviesado para cima — 2 blocos abaixo do player contra 10 acima, já que abaixo costuma ser sólido.

## Causa 2 — opacidade por puff ~10x baixa demais

Cada puff contribuía `alpha 0.096 × alpha_média_da_textura 0.131` ≈ **1,3%**. Com só 60 puffs vivos, isso dava 6% de opacidade numa linha de visão de 16 blocos.

| cenário | puffs na linha | opacidade |
|---|---:|---:|
| pântano, antes | 4.8 | **6%** |
| pântano, depois | 25.7 | **78%** |
| planície inverno, depois | 9.6 | 35% |

**Conserto:** `BASE_ALPHA` 0.10 → 0.45, `BASE_SCALE` 3.0 → 4.5, `MAX_PARTICLES` 180 → 260.

## O que NÃO mudou, e por quê

O guard `client.isPaused()` **fica**. Cheguei a chamar isso de defeito durante a investigação e estava errado: com o jogo pausado as partículas não envelhecem, então spawnar durante a pausa acumularia sem limite. A névoa já existente continua visível durante a pausa.

## Como testar

1. Pântano: o ar deve ficar claramente verde e pesado, **dificultando a visão de verdade**.
2. Planície no inverno: névoa fria fina, bem mais sutil que o pântano.
3. Planície no verão: continua limpo.
4. Deserto: nada.
5. Caverna: a correção de retry ajuda bastante aqui também — caverna é cheia de bloco sólido.
6. **FPS no pântano.** É o pior caso: 244 puffs de quads grandes. Se cair, `MAX_PARTICLES` é o número.

## Contexto

Correção sobre `feat/mist-weather-response` (base deste PR), feature `add-biome-mist`.

A branch `debug/mist-diagnostics` foi o que produziu o log acima. É descartável e pode ser deletada.
