### PR TITLE
feat: nevar fora dos biomas frios durante o inverno

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/ClientSeasonState.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ClientSeasonState.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools.client;
 
 import net.abakath.rpg4fools.enums.Months;
 import net.abakath.rpg4fools.enums.SubSeason;
+import net.abakath.rpg4fools.world.SeasonSnow;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -63,6 +64,10 @@ public final class ClientSeasonState {
     lastDay = day;
 
     subSeason = Months.values()[monthOrdinal].getSubSeason();
+
+    // Keeps the client half of the precipitation mixin in step, so rain renders as snow at the same
+    // moment the server starts laying it down.
+    SeasonSnow.setSubSeason(subSeason);
     progress = ColorMath.clamp01((float) (day - 1) / MONTH_DURATION);
 
     MinecraftClient client = MinecraftClient.getInstance();

--- a/src/main/java/net/abakath/rpg4fools/init/ModEvents.java
+++ b/src/main/java/net/abakath/rpg4fools/init/ModEvents.java
@@ -2,10 +2,12 @@ package net.abakath.rpg4fools.init;
 
 
 import net.abakath.rpg4fools.server.events.DayChangingHandler;
+import net.abakath.rpg4fools.server.events.SnowMeltHandler;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 public class ModEvents {
   public static void registerEvents() {
     ServerTickEvents.START_SERVER_TICK.register(new DayChangingHandler());
+    ServerTickEvents.START_SERVER_TICK.register(new SnowMeltHandler());
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/mixin/BiomePrecipitationMixin.java
+++ b/src/main/java/net/abakath/rpg4fools/mixin/BiomePrecipitationMixin.java
@@ -1,0 +1,45 @@
+package net.abakath.rpg4fools.mixin;
+
+import net.abakath.rpg4fools.world.SeasonSnow;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Turns rain into snow in the cold months, for biomes cold enough to qualify.
+ *
+ * <p>This one method is where vanilla decides rain against snow for weather rendering, for whether
+ * a chunk tick lays down a snow layer, and for whether standing water freezes. Overriding it here
+ * means all three follow the season together rather than being wired up separately.
+ *
+ * <p>Only a RAIN result is changed. A biome that returns NONE has no precipitation at all, which is
+ * what keeps desert, savanna and badlands dry without naming them, and a biome already returning
+ * SNOW is left alone so snowy and taiga behave as they always did.
+ *
+ * <p>Deliberately in the common mixin config: the server needs this to accumulate snow, and the
+ * client needs it to draw snow instead of rain.
+ */
+@Mixin(Biome.class)
+public abstract class BiomePrecipitationMixin {
+  @Inject(method = "getPrecipitation", at = @At("RETURN"), cancellable = true)
+  private void rpg4fools$applyWinterSnowLine(BlockPos pos, CallbackInfoReturnable<Biome.Precipitation> cir) {
+    if (cir.getReturnValue() != Biome.Precipitation.RAIN) {
+      return;
+    }
+
+    if (!SeasonSnow.isSnowSeason()) {
+      return;
+    }
+
+    Biome biome = (Biome) (Object) this;
+
+    if (biome.getTemperature() > SeasonSnow.snowLineTemperature()) {
+      return;
+    }
+
+    cir.setReturnValue(Biome.Precipitation.SNOW);
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/mixin/BiomePrecipitationMixin.java
+++ b/src/main/java/net/abakath/rpg4fools/mixin/BiomePrecipitationMixin.java
@@ -26,20 +26,29 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class BiomePrecipitationMixin {
   @Inject(method = "getPrecipitation", at = @At("RETURN"), cancellable = true)
   private void rpg4fools$applyWinterSnowLine(BlockPos pos, CallbackInfoReturnable<Biome.Precipitation> cir) {
-    if (cir.getReturnValue() != Biome.Precipitation.RAIN) {
+    Biome.Precipitation vanilla = cir.getReturnValue();
+
+    // NONE means the biome has no precipitation at all. That is what keeps desert, savanna and
+    // badlands dry without naming any of them, so it is never overridden in either direction.
+    if (vanilla == Biome.Precipitation.NONE) {
       return;
     }
 
-    if (!SeasonSnow.isSnowSeason()) {
+    float temperature = ((Biome) (Object) this).getTemperature();
+
+    if (vanilla == Biome.Precipitation.RAIN) {
+      if (SeasonSnow.isSnowSeason() && temperature <= SeasonSnow.snowLineTemperature()) {
+        cir.setReturnValue(Biome.Precipitation.SNOW);
+      }
+
       return;
     }
 
-    Biome biome = (Biome) (Object) this;
-
-    if (biome.getTemperature() > SeasonSnow.snowLineTemperature()) {
-      return;
+    // The inverse case. Without it a mild snowy biome would keep snowing right through the
+    // midsummer thaw, so the melt pass would be clearing ground that the next snowfall covers
+    // straight back up.
+    if (SeasonSnow.shouldThaw(temperature)) {
+      cir.setReturnValue(Biome.Precipitation.RAIN);
     }
-
-    cir.setReturnValue(Biome.Precipitation.SNOW);
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
@@ -4,6 +4,7 @@ import net.abakath.rpg4fools.enums.Months;
 import net.abakath.rpg4fools.models.DayData;
 import net.abakath.rpg4fools.network.packets.s2c.SeasonUpdatePacket;
 import net.abakath.rpg4fools.server.SeasonData;
+import net.abakath.rpg4fools.world.SeasonSnow;
 import net.abakath.rpg4fools.utils.IEntityDataSaver;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -29,6 +30,10 @@ public class DayChangingHandler implements ServerTickEvents.StartTick {
             SeasonData seasonData = SeasonData.getServerState(server);
 
             seasonData.setSubSeason(dayData.getMonth().getSubSeason());
+
+            // The precipitation mixin reads this on both sides. The server half is set here rather
+            // than read back from SeasonData, so the hot path never touches persistent state.
+            SeasonSnow.setSubSeason(dayData.getMonth().getSubSeason());
 
             server.getPlayerManager().getPlayerList().forEach(player -> {
                 DayData.setPlayerDayData((IEntityDataSaver) player, dayData);

--- a/src/main/java/net/abakath/rpg4fools/server/events/SnowMeltHandler.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/SnowMeltHandler.java
@@ -1,0 +1,96 @@
+package net.abakath.rpg4fools.server.events;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.minecraft.block.Blocks;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+
+/**
+ * Removes snow and ice once the season stops putting it there.
+ *
+ * <p>Vanilla never melts surface snow from daylight. SnowBlock only melts beside a block light
+ * source above level 11, which is right for a biome meant to stay white but would leave a plains
+ * permanently snowed over after a single winter.
+ *
+ * <p>Samples positions around each player rather than walking loaded chunks. That is where vanilla
+ * laid the snow down in the first place, since chunk ticks only run near players, so it is the same
+ * ground either way and it keeps the work proportional to how many people are online.
+ *
+ * <p>Deliberately not a mixin. Melting needs no vanilla internals, and ServerWorld.tickChunk is a
+ * private method whose signature can only be checked by launching the game.
+ */
+public class SnowMeltHandler implements ServerTickEvents.StartTick {
+  /** Ticks between passes. Thawing is meant to take days, not to clear a region at once. */
+  private static final int TICK_INTERVAL = 20;
+
+  /** Positions examined per player per pass. */
+  private static final int SAMPLES_PER_PLAYER = 8;
+
+  /** Horizontal reach of the sampling, in blocks. */
+  private static final int SAMPLE_RADIUS = 96;
+
+  private int tickCounter = 0;
+
+  @Override
+  public void onStartTick(MinecraftServer server) {
+    if (++tickCounter < TICK_INTERVAL) {
+      return;
+    }
+
+    tickCounter = 0;
+
+    ServerWorld overworld = server.getWorld(World.OVERWORLD);
+
+    if (overworld == null) {
+      return;
+    }
+
+    for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+      if (player.getWorld() != overworld) {
+        continue;
+      }
+
+      for (int i = 0; i < SAMPLES_PER_PLAYER; i++) {
+        meltOneSample(overworld, player.getBlockPos());
+      }
+    }
+  }
+
+  private void meltOneSample(ServerWorld world, BlockPos around) {
+    Random random = world.getRandom();
+
+    int x = around.getX() + random.nextInt(SAMPLE_RADIUS * 2) - SAMPLE_RADIUS;
+    int z = around.getZ() + random.nextInt(SAMPLE_RADIUS * 2) - SAMPLE_RADIUS;
+
+    if (!world.isChunkLoaded(x >> 4, z >> 4)) {
+      return;
+    }
+
+    BlockPos top = world.getTopPosition(Heightmap.Type.MOTION_BLOCKING, new BlockPos(x, 0, z));
+    Biome biome = world.getBiome(top).value();
+
+    // Still snowing here, so nothing is out of season. This is also what protects the biomes that
+    // are frozen year round: their precipitation never stops being SNOW.
+    if (biome.getPrecipitation(top) == Biome.Precipitation.SNOW) {
+      return;
+    }
+
+    // Only snow layers, never SNOW_BLOCK, so anything a player built out of snow survives.
+    if (world.getBlockState(top).isOf(Blocks.SNOW)) {
+      world.removeBlock(top, false);
+      return;
+    }
+
+    BlockPos below = top.down();
+
+    if (world.getBlockState(below).isOf(Blocks.ICE)) {
+      world.setBlockState(below, Blocks.WATER.getDefaultState());
+    }
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/server/events/SnowMeltHandler.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/SnowMeltHandler.java
@@ -1,5 +1,6 @@
 package net.abakath.rpg4fools.server.events;
 
+import net.abakath.rpg4fools.world.SeasonSnow;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.block.Blocks;
 import net.minecraft.server.MinecraftServer;
@@ -75,15 +76,19 @@ public class SnowMeltHandler implements ServerTickEvents.StartTick {
     BlockPos top = world.getTopPosition(Heightmap.Type.MOTION_BLOCKING, new BlockPos(x, 0, z));
     Biome biome = world.getBiome(top).value();
 
-    // Still snowing here, so nothing is out of season. This is also what protects the biomes that
-    // are frozen year round: their precipitation never stops being SNOW.
-    if (biome.getPrecipitation(top) == Biome.Precipitation.SNOW) {
+    if (!SeasonSnow.shouldThaw(biome.getTemperature())) {
       return;
     }
 
     // Only snow layers, never SNOW_BLOCK, so anything a player built out of snow survives.
     if (world.getBlockState(top).isOf(Blocks.SNOW)) {
       world.removeBlock(top, false);
+      return;
+    }
+
+    // Ice survives the midsummer thaw. Clearing a snowy plains of its cover for a month is the
+    // intent; draining a frozen ocean and stranding whatever was standing on it is not.
+    if (SeasonSnow.isMidsummerThaw()) {
       return;
     }
 

--- a/src/main/java/net/abakath/rpg4fools/world/SeasonSnow.java
+++ b/src/main/java/net/abakath/rpg4fools/world/SeasonSnow.java
@@ -1,0 +1,59 @@
+package net.abakath.rpg4fools.world;
+
+import net.abakath.rpg4fools.enums.SubSeason;
+
+/**
+ * The temperature below which it snows, for the season currently in effect.
+ *
+ * <p>Read from {@code Biome.getPrecipitation}, which runs on the server for every chunk tick and on
+ * the client for weather rendering, so the lookup is deliberately a single volatile read and one
+ * float comparison.
+ *
+ * <p>Held statically rather than passed around because both sides need it and neither has a handle
+ * on the other's season state: the server owns SeasonData, the client owns ClientSeasonState. Both
+ * write here. In single player they share a JVM and write the same value, which is harmless.
+ */
+public final class SeasonSnow {
+  /**
+   * Vanilla snows below this temperature. Used outside the cold months so the mixin never overrides
+   * anything: if vanilla already returned RAIN the biome is warmer than this, and the check fails.
+   */
+  private static final float VANILLA_SNOW_TEMPERATURE = 0.15f;
+
+  private static volatile SubSeason subSeason = SubSeason.EARLY_SPRING;
+
+  private SeasonSnow() {
+  }
+
+  public static void setSubSeason(SubSeason current) {
+    if (current != null) {
+      subSeason = current;
+    }
+  }
+
+  public static SubSeason getSubSeason() {
+    return subSeason;
+  }
+
+  /**
+   * Biomes at or below this temperature snow right now.
+   *
+   * <p>The line climbs as winter deepens and pulls back afterwards, so snow spreads out from the
+   * already cold biomes and retreats rather than switching on across the map. Jungle sits at 0.95
+   * and is deliberately above every value here.
+   */
+  public static float snowLineTemperature() {
+    return switch (subSeason) {
+      case LATE_AUTUMN -> 0.30f;
+      case EARLY_WINTER -> 0.60f;
+      case MID_WINTER -> 0.90f;
+      case LATE_WINTER -> 0.70f;
+      default -> VANILLA_SNOW_TEMPERATURE;
+    };
+  }
+
+  /** True when the season is pushing snow past its vanilla range. */
+  public static boolean isSnowSeason() {
+    return snowLineTemperature() > VANILLA_SNOW_TEMPERATURE;
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/world/SeasonSnow.java
+++ b/src/main/java/net/abakath/rpg4fools/world/SeasonSnow.java
@@ -56,4 +56,41 @@ public final class SeasonSnow {
   public static boolean isSnowSeason() {
     return snowLineTemperature() > VANILLA_SNOW_TEMPERATURE;
   }
+
+  /**
+   * Biomes at or below this never thaw, whatever the season. Snowy taiga sits at -0.5 and the peaks
+   * at -0.7, so those stay frozen year round, while snowy plains and snowy beach sit at 0.0 and
+   * above and can lose their cover at the height of summer.
+   */
+  private static final float PERMAFROST_TEMPERATURE = -0.15f;
+
+  /**
+   * Whether snow lying at a biome of this temperature should be melting right now.
+   *
+   * <p>Snowy biomes are supposed to be white. Their precipitation never stops being snow, so the
+   * ordinary rule below already leaves them alone all year, which is what keeps their existing
+   * cover intact through the season cycle.
+   *
+   * <p>Midsummer is the one exception, and only for the milder of them. A snowy plains losing its
+   * cover for a month reads as a thaw; frozen peaks doing the same would just look broken.
+   */
+  public static boolean shouldThaw(float biomeTemperature) {
+    if (subSeason == SubSeason.MID_SUMMER) {
+      return biomeTemperature > PERMAFROST_TEMPERATURE;
+    }
+
+    // Anything at or below the current snow line is actively being snowed on, so it is not thawing.
+    // For a snowy biome that condition holds in every season, which is the year round protection.
+    return biomeTemperature > snowLineTemperature();
+  }
+
+  /**
+   * True when the thaw is the midsummer exception rather than the ordinary end of winter.
+   *
+   * <p>The caller uses this to leave ice alone: clearing a snowy plains of its snow for a month is
+   * the intent, draining a frozen ocean is not.
+   */
+  public static boolean isMidsummerThaw() {
+    return subSeason == SubSeason.MID_SUMMER;
+  }
 }

--- a/src/main/resources/rpg4fools.mixins.json
+++ b/src/main/resources/rpg4fools.mixins.json
@@ -4,9 +4,10 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "ModEntityDataSaverMixin",
-    "RPG4FoolsMixin"
+    "RPG4FoolsMixin",
+    "BiomePrecipitationMixin"
   ],
   "injectors": {
     "defaultRequire": 1
-	}
+  }
 }


### PR DESCRIPTION
## Descrição

A neve passa a se espalhar além do alcance vanilla conforme o inverno aprofunda, e recua depois. Chega em planície e floresta no auge, deixa os biomas quentes em paz o ano todo, e os biomas nevados permanecem nevados — exceto um degelo de meio de verão nos mais amenos.

## Tabela completa: bioma x sub season

**`neva`** = precipitação vira neve e acumula · `degelo` = chove, e a neve deixada por esta feature derrete · `chuva` = chove, o bioma nunca acumula neve · `—` = bioma sem precipitação alguma

| bioma | temp | E.Pri | M.Pri | L.Pri | E.Ver | M.Ver | L.Ver | E.Out | M.Out | L.Out | E.Inv | M.Inv | L.Inv |
|---|---:|---|---|---|---|---|---|---|---|---|---|---|---|
| frozen peaks | -0.7 | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| snowy taiga | -0.5 | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| snowy slopes | -0.3 | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| grove | -0.2 | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| snowy plains | 0.0 | **neva** | **neva** | **neva** | **neva** | degelo | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| ice spikes | 0.0 | **neva** | **neva** | **neva** | **neva** | degelo | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| frozen river | 0.0 | **neva** | **neva** | **neva** | **neva** | degelo | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| frozen ocean | 0.0 | **neva** | **neva** | **neva** | **neva** | degelo | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| snowy beach | 0.05 | **neva** | **neva** | **neva** | **neva** | degelo | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** | **neva** |
| taiga | 0.25 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | **neva** | **neva** | **neva** |
| old growth taiga | 0.3 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | **neva** | **neva** | **neva** |
| birch forest | 0.6 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | **neva** | **neva** |
| forest | 0.7 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | **neva** |
| dark forest | 0.7 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | **neva** |
| plains | 0.8 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | degelo |
| swamp | 0.8 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | degelo |
| beach | 0.8 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | degelo |
| mushroom fields | 0.9 | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | degelo | **neva** | degelo |
| jungle | 0.95 | chuva | chuva | chuva | chuva | chuva | chuva | chuva | chuva | chuva | chuva | chuva | chuva |
| savanna | 1.2 | — | — | — | — | — | — | — | — | — | — | — | — |
| desert | 2.0 | — | — | — | — | — | — | — | — | — | — | — | — |
| badlands | 2.0 | — | — | — | — | — | — | — | — | — | — | — | — |
Nenhum bioma neva e degela na mesma sub season.

## As três regras

**Linha de neve** — o limite de temperatura sobe conforme o inverno aprofunda e recua depois, então a neve se espalha a partir dos biomas já frios em vez de ligar no mapa inteiro.

| sub season | limite | passa a nevar em |
|---|---:|---|
| LATE_AUTUMN | 0.30 | taiga, old growth taiga |
| EARLY_WINTER | 0.60 | + birch forest |
| MID_WINTER | 0.90 | + forest, plains, swamp, beach, mushroom fields |
| LATE_WINTER | 0.70 | recua até floresta |
| demais | 0.15 | vanilla |

Selva está em 0.95, acima de todas — nunca neva.

**Permafrost** — biomas em `-0.15` ou abaixo nunca degelam: frozen peaks (`-0.7`), snowy taiga (`-0.5`), snowy slopes (`-0.3`), grove (`-0.2`).

**Degelo de meio de verão** — snowy plains, ice spikes, frozen river, frozen ocean e snowy beach (`0.0` a `0.05`) perdem a cobertura durante o `MID_SUMMER` e recuperam depois.

## Um ponto só de decisão

`Biome.getPrecipitation` é onde o vanilla escolhe chuva ou neve. A mesma resposta comanda **três coisas**: renderização do clima, se o chunk tick deposita camada de neve, e se a água congela. O mixin trata as duas direções:

- `RAIN` → `SNOW` quando a season empurra a linha de neve além do bioma
- `SNOW` → `RAIN` quando o bioma está degelando
- `NONE` nunca é tocado, em direção nenhuma — é o que mantém deserto, savana e badlands fora disso sem precisar nomeá-los

O caso inverso não estava no design original. Montar esta tabela expôs que uma snowy plains no meio do verão degelava **e** nevava ao mesmo tempo: a precipitação continuava `SNOW` porque o bioma está abaixo do limite vanilla, então o handler limpava chão que a próxima nevasca cobria de volta.

## Derretimento

O vanilla nunca derrete neve de superfície por luz do sol — `SnowBlock` só derrete ao lado de fonte de luz de bloco acima do nível 11. Uma planície que nevasse uma vez ficaria branca para sempre, então o derretimento precisou ser construído.

`SnowMeltHandler` amostra o chão em volta de cada player uma vez por segundo. É o mesmo chão onde o vanilla depositou, já que chunk ticks só rodam perto de players.

**Só camadas de neve, nunca `SNOW_BLOCK`** — o que o player construiu sobrevive.

**Gelo sobrevive ao degelo de meio de verão.** Limpar a neve de uma snowy plains por um mês é a intenção; drenar um oceano congelado e deixar preso o que estivesse em cima não é. O gelo ainda derrete no fim do inverno normal, onde ele só existe porque este mod congelou.

## Decisões de implementação

**O mixin fica no config comum**, não no client: o servidor precisa dele para acumular e o cliente para desenhar neve em vez de chuva. Lê um holder estático em vez do estado de season, porque o servidor tem `SeasonData` e o cliente tem `ClientSeasonState` e nenhum enxerga o outro. A leitura é um volatile e um compare de float, que importa num método chamado a cada chunk tick.

**O derretimento não é mixin.** Não precisa de nada interno do vanilla, e `ServerWorld.tickChunk` é privado — a assinatura só se verifica abrindo o jogo. Handler de tick do Fabric elimina esse risco. Sobrou um mixin novo em vez de dois.

## Isso escreve no save

Um mundo que passar um inverno vai ter neve real na planície, e ela some ao longo da primavera. Use mundo de teste — se o derretimento tiver furo, sobra neve no save.

## Como testar

1. `MID_WINTER` numa planície: neve caindo e **acumulando**, água congelando.
2. Deserto e savana em `MID_WINTER`: **nada**, nem neve nem chuva.
3. Selva em `MID_WINTER`: chuva normal.
4. Avançar para primavera e confirmar que a neve da planície some andando pela região.
5. Snowy plains em `MID_WINTER`: neve normal. Em `MID_SUMMER`: **chove e degela**. Depois volta a nevar.
6. Snowy taiga ou frozen peaks em `MID_SUMMER`: continua nevando, **sem degelo**.
7. Construir com `SNOW_BLOCK` e confirmar que sobrevive a tudo.
8. `runServer` sobe sem crashar — o mixin está no config comum, é o caminho que importa.

## Ponto de atenção pra review

`method = "getPrecipitation"` só resolve quando o jogo abre. É o único mixin novo; se estiver errado crasha no launch em vez de falhar silencioso.

Borda discutível: **ice spikes** tem temperatura `0.0`, igual à snowy plains, então perde a camada de neve no meio do verão. As estruturas de `PACKED_ICE` e `BLUE_ICE` não são tocadas. Separar os dois exigiria distinção por tag, não por temperatura.

## Contexto

Base: `feat/add-season-changes-on-world`. Independente do PR #33, que está em `fix/biome-fog-instead-of-particles`.
