### PR TITLE
fix: grant contents write to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `Create release` run on master ([#33197250865](https://github.com/CauaKath/rpg-4-fools-mod/actions/runs/33197250865)) built fine but failed on the release step:

```
Could not create new tag "refs/tags/latest" (Resource not accessible by integration)
##[error]Resource not accessible by integration
```

The repository default workflow permission is read-only:

```json
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

`release.yml` declares no `permissions:` block, so `GITHUB_TOKEN` cannot create the `latest` tag or publish the release. The workflow is new (added in 9c1d82a), so this is its first run rather than a regression.

## Change

Add `permissions: contents: write` to the `build-and-deploy` job.

Scoped to the job rather than flipping Settings → Actions → Workflow permissions, so the grant is explicit, minimal, and tracked in git.

## Verification

CI on this branch only exercises `build.yml`; `release.yml` runs on push to master, so the fix is confirmed by the next master run producing the `latest` tag and release.

## Not included

Two adjacent issues left out of this PR:

- `marvinpinto/action-automatic-releases` has been archived since 2023 and is pinned to a floating `@latest`. `softprops/action-gh-release@v2` is the maintained replacement.
- `build.yml` triggers on `[pull_request, push]`, so every master push builds twice — once in `build`, once in `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)