### PR TITLE
chore: stop building feature branches twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,16 @@
-# Automatically build the project and run any configured tests for every push
-# and submitted pull request. This can help catch issues that only occur on
-# certain platforms or Java versions, and provides a first line of defence
-# against bad commits.
+# Automatically build the project and run any configured tests for every
+# submitted pull request and every push to master. This can help catch issues
+# that only occur on certain platforms or Java versions, and provides a first
+# line of defence against bad commits.
 
 name: build
-on: [pull_request, push]
+# Runs on pull requests and on master. Plain `push` would also fire for every
+# feature-branch push, building the same commit twice whenever a PR is open.
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
## Problem

`build.yml` triggered on `on: [pull_request, push]`. Bare `push` fires for every branch, so any branch with an open PR built the same commit twice. From the recent run history:

```
17:51:48  build  feat/winter-snow  pull_request
17:51:47  build  feat/winter-snow  push
```

Two ~1.5 minute runs, same commit, same result.

## Change

```yaml
on:
  pull_request:
  push:
    branches:
      - master
```

Effect per event:

| event | before | after |
|---|---|---|
| push to a branch with an open PR | 2 builds | 1 |
| push to a branch with no PR | 1 build | 0 (builds once the PR opens) |
| merge to master | 3 builds (`build` + `release` + `release-version`) | unchanged |

Master is deliberately kept: `release.yml` does compile on every master push, but leaving `build.yml` there preserves a plain build check for commits pushed straight to master, and keeps `build (21)` reporting on master as it does today.

Also refreshes the stale file header, which described the old trigger.

## Why keep the PR build

There is no local JDK on this setup, so CI is the only compile check that exists. Dropping the PR trigger would mean a broken Mixin or refmap only surfaces after it is on master, turning master red and blocking the release workflows until it is reverted. Catching it on the PR costs the same minutes with none of the cleanup.

## Verification

`build.yml` parses as valid YAML. The trigger change is self-verifying: this PR's own `build (21)` check runs from the `pull_request` event, and the branch produces no second `push` run.

Touches `build.yml` only, so no conflict with #35 or #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)