### PR TITLE
Show a crop's seasons in its tooltip

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
+++ b/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
@@ -1,6 +1,7 @@
 package net.abakath.rpg4fools;
 
 import net.abakath.rpg4fools.client.ClientModMessages;
+import net.abakath.rpg4fools.client.CropSeasonTooltip;
 import net.abakath.rpg4fools.client.SeasonAtmosphere;
 import net.abakath.rpg4fools.client.SeasonColorProviders;
 import net.abakath.rpg4fools.client.SeasonsHudOverlay;
@@ -15,6 +16,7 @@ public class RPG4FoolsClient implements ClientModInitializer {
 
     ClientModMessages.registerS2CReceivers();
     SeasonColorProviders.register();
+    CropSeasonTooltip.register();
 
     // Biome tags arrive as part of the join handshake. Anything resolved before they land falls
     // back to DEFAULT, and the atmosphere memoises per registry entry, so that wrong answer would

--- a/src/main/java/net/abakath/rpg4fools/client/CropSeasonTooltip.java
+++ b/src/main/java/net/abakath/rpg4fools/client/CropSeasonTooltip.java
@@ -1,0 +1,92 @@
+package net.abakath.rpg4fools.client;
+
+import net.abakath.rpg4fools.enums.Season;
+import net.abakath.rpg4fools.world.CropItems;
+import net.abakath.rpg4fools.world.CropSeasons;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds a crop's growing seasons to its tooltip, for the crop and for its seed alike.
+ *
+ * <p>Hidden behind Shift. A season list is reference material a player wants once per crop, not
+ * every time they mouse over their inventory, so the default tooltip stays as short as vanilla's.
+ *
+ * <p>Each season is written in its own colour, which means colour cannot also mean "now". The
+ * current season is bolded instead.
+ */
+@Environment(EnvType.CLIENT)
+public final class CropSeasonTooltip {
+  private CropSeasonTooltip() {
+  }
+
+  public static void register() {
+    ItemTooltipCallback.EVENT.register((stack, tooltipContext, tooltipType, lines) -> append(stack, lines));
+  }
+
+  private static void append(ItemStack stack, List<Text> lines) {
+    Optional<BlockState> crop = CropItems.cropFor(stack);
+
+    if (crop.isEmpty()) {
+      return;
+    }
+
+    if (!Screen.hasShiftDown()) {
+      lines.add(Text.translatable("tooltip.rpg4fools.hold_shift").formatted(Formatting.DARK_GRAY, Formatting.ITALIC));
+      return;
+    }
+
+    lines.add(Text.translatable("tooltip.rpg4fools.seasons", seasonList(crop.get())).formatted(Formatting.GRAY));
+  }
+
+  private static MutableText seasonList(BlockState crop) {
+    EnumSet<Season> seasons = CropSeasons.getSeasons(crop);
+    Season current = currentSeason();
+
+    MutableText list = Text.empty();
+    boolean first = true;
+
+    for (Season season : seasons) {
+      if (!first) {
+        list.append(Text.literal(", ").formatted(Formatting.GRAY));
+      }
+
+      MutableText name = Text.literal(season.getName()).formatted(season.getColor());
+      if (season == current) {
+        name.formatted(Formatting.BOLD);
+      }
+
+      list.append(name);
+      first = false;
+    }
+
+    return list;
+  }
+
+  /**
+   * The season the player is standing in, or null outside a world.
+   *
+   * <p>ClientSeasonState carries a default season so rendering always has something to work with.
+   * That default is a lie in a tooltip, where bolding a season would claim it is the current one,
+   * so the world is checked rather than trusting the cached value on its own.
+   */
+  private static Season currentSeason() {
+    if (MinecraftClient.getInstance().world == null) {
+      return null;
+    }
+
+    return ClientSeasonState.getSubSeason().getSeason();
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/enums/Season.java
+++ b/src/main/java/net/abakath/rpg4fools/enums/Season.java
@@ -1,6 +1,7 @@
 package net.abakath.rpg4fools.enums;
 
 import net.abakath.rpg4fools.RPG4Fools;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 public enum Season {
@@ -24,6 +25,21 @@ public enum Season {
             case SUMMER -> new Identifier(RPG4Fools.MOD_ID, "textures/gui/summer.png");
             case AUTUMN -> new Identifier(RPG4Fools.MOD_ID, "textures/gui/autumn.png");
             case WINTER -> new Identifier(RPG4Fools.MOD_ID, "textures/gui/winter.png");
+        };
+    }
+
+    /**
+     * Colour the season is written in, for anything that names a season in text.
+     *
+     * <p>Vanilla formatting codes rather than RGB, so the colours follow whatever the player's
+     * client already does with them and stay readable against every tooltip background.
+     */
+    public Formatting getColor() {
+        return switch (this) {
+            case SPRING -> Formatting.GREEN;
+            case SUMMER -> Formatting.YELLOW;
+            case AUTUMN -> Formatting.GOLD;
+            case WINTER -> Formatting.AQUA;
         };
     }
 

--- a/src/main/java/net/abakath/rpg4fools/world/CropItems.java
+++ b/src/main/java/net/abakath/rpg4fools/world/CropItems.java
@@ -1,0 +1,74 @@
+package net.abakath.rpg4fools.world;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves an item back to the crop it belongs to.
+ *
+ * <p>Seasons live on blocks, but the player holds items. Both halves of a crop should answer the
+ * same question, so a seed and the thing it grows into both have to find their way back to one
+ * block state.
+ *
+ * <p>Most of that is free: a seed is a BlockItem pointing at the crop it plants, so deriving the
+ * block covers every vanilla seed and any modded seed this mod has never heard of. The map below
+ * only exists for produce that is not its crop's BlockItem - wheat and beetroot are plain items,
+ * and melon and pumpkin are BlockItems of the fruit rather than of the stem that grew it.
+ */
+public class CropItems {
+  private static final Map<Item, Block> PRODUCE = createProduce();
+
+  /** The crop this item belongs to, or empty if the item has nothing to do with farming. */
+  public static Optional<BlockState> cropFor(ItemStack stack) {
+    Item item = stack.getItem();
+
+    // Checked before the map so a modded seed resolves without needing an entry. The crops tag is
+    // what decides; a BlockItem for some unrelated block falls through.
+    if (item instanceof BlockItem blockItem) {
+      BlockState planted = blockItem.getBlock().getDefaultState();
+
+      if (CropSeasons.isCrop(planted)) {
+        return Optional.of(planted);
+      }
+    }
+
+    Block grownBy = PRODUCE.get(item);
+    if (grownBy == null) {
+      return Optional.empty();
+    }
+
+    BlockState crop = grownBy.getDefaultState();
+
+    // The map is written against vanilla, but a datapack can drop a crop out of the tag. Honour
+    // that instead of reporting seasons for something no longer treated as a crop.
+    return CropSeasons.isCrop(crop) ? Optional.of(crop) : Optional.empty();
+  }
+
+  private static Map<Item, Block> createProduce() {
+    Map<Item, Block> produce = new LinkedHashMap<>();
+
+    produce.put(Items.WHEAT, Blocks.WHEAT);
+    produce.put(Items.BEETROOT, Blocks.BEETROOTS);
+
+    // Stems, not the fruit. Blocks.MELON and Blocks.PUMPKIN are the harvest, and neither one grows
+    // on its own, so the seasons that matter are the stem's.
+    produce.put(Items.MELON, Blocks.MELON_STEM);
+    produce.put(Items.MELON_SLICE, Blocks.MELON_STEM);
+    produce.put(Items.PUMPKIN, Blocks.PUMPKIN_STEM);
+
+    // Grown flowers, whose block items place the finished plant rather than the crop stage.
+    produce.put(Items.TORCHFLOWER, Blocks.TORCHFLOWER_CROP);
+    produce.put(Items.PITCHER_PLANT, Blocks.PITCHER_CROP);
+
+    return produce;
+  }
+}

--- a/src/main/resources/assets/rpg4fools/lang/en_us.json
+++ b/src/main/resources/assets/rpg4fools/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "tooltip.rpg4fools.hold_shift": "Hold Shift for seasons",
+  "tooltip.rpg4fools.seasons": "Seasons: %s"
+}


### PR DESCRIPTION
## What

Hover a crop or its seed, hold Shift, and the tooltip lists the seasons that crop grows in. Reads the `CropSeasons` tags added in #39; no gameplay change.

```
Wheat
<Hold Shift for seasons>          ← dark grey, italic

-- shift held --
Wheat
Seasons: Spring, Summer, Autumn
                 ^bold when it is currently Summer
```

## Colours

| Season | Formatting |
|---|---|
| Spring | `GREEN` |
| Summer | `YELLOW` |
| Autumn | `GOLD` |
| Winter | `AQUA` |

Vanilla formatting codes rather than RGB, so they follow the player's client settings and stay legible on every tooltip background. Since colour now identifies the season, it can't also mean "now" — the current season is **bold** instead.

Outside a world nothing is bolded: `ClientSeasonState` carries a default season so rendering always has a value, and bolding it in a tooltip would assert a season the player isn't in.

## Item → crop mapping

`CropItems.cropFor(stack)` tries `BlockItem` → its block first, keeping it only if it's in `#rpg4fools:crops`. That covers every vanilla seed and modded seeds this mod has never heard of. The explicit table is only for produce that isn't its crop's own `BlockItem`:

| Item | Crop |
|---|---|
| `wheat`, `beetroot` | plain items, not BlockItems |
| `melon`, `melon_slice`, `pumpkin` | place the fruit, not the stem |
| `torchflower`, `pitcher_plant` | place the finished plant, not the crop stage |

Lives in `world/` rather than `client/` — a later planting-restriction check wants the same mapping.

## Notes for review

- New `Season.getColor()` sits beside `getName()`/`getSeasonTexture()`, exhaustive switch like the rest of the enum. `Formatting` is a common class, so the enum stays environment-neutral.
- First `lang/en_us.json` in the repo, two keys. Season names still come from `Season.getName()` so there's one place naming seasons — which does mean season names aren't translatable yet. Pre-existing (the HUD overlay does the same); worth its own change if localisation matters.
- **Not run in-game.** No JDK in the dev environment here, so CI compile is the only check. A tooltip needs eyes: hover wheat, wheat seeds, a melon slice, a pumpkin, and a stick (should get no line at all), with and without Shift, and confirm the bold lands on the right season.

🤖 Generated with [Claude Code](https://claude.com/claude-code)