### PR TITLE
Refuse to plant crops out of season

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/client/ClientSeasonState.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ClientSeasonState.java
@@ -2,7 +2,7 @@ package net.abakath.rpg4fools.client;
 
 import net.abakath.rpg4fools.enums.Months;
 import net.abakath.rpg4fools.enums.SubSeason;
-import net.abakath.rpg4fools.world.SeasonSnow;
+import net.abakath.rpg4fools.world.CurrentSeason;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -67,7 +67,7 @@ public final class ClientSeasonState {
 
     // Keeps the client half of the precipitation mixin in step, so rain renders as snow at the same
     // moment the server starts laying it down.
-    SeasonSnow.setSubSeason(subSeason);
+    CurrentSeason.set(subSeason);
     progress = ColorMath.clamp01((float) (day - 1) / MONTH_DURATION);
 
     MinecraftClient client = MinecraftClient.getInstance();

--- a/src/main/java/net/abakath/rpg4fools/init/ModEvents.java
+++ b/src/main/java/net/abakath/rpg4fools/init/ModEvents.java
@@ -3,6 +3,7 @@ package net.abakath.rpg4fools.init;
 
 import net.abakath.rpg4fools.server.events.CropTagValidator;
 import net.abakath.rpg4fools.server.events.DayChangingHandler;
+import net.abakath.rpg4fools.server.events.SeasonPlantingGate;
 import net.abakath.rpg4fools.server.events.SnowMeltHandler;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
@@ -12,5 +13,6 @@ public class ModEvents {
     ServerTickEvents.START_SERVER_TICK.register(new SnowMeltHandler());
 
     CropTagValidator.register();
+    SeasonPlantingGate.register();
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
@@ -4,7 +4,7 @@ import net.abakath.rpg4fools.enums.Months;
 import net.abakath.rpg4fools.models.DayData;
 import net.abakath.rpg4fools.network.packets.s2c.SeasonUpdatePacket;
 import net.abakath.rpg4fools.server.SeasonData;
-import net.abakath.rpg4fools.world.SeasonSnow;
+import net.abakath.rpg4fools.world.CurrentSeason;
 import net.abakath.rpg4fools.utils.IEntityDataSaver;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -33,7 +33,7 @@ public class DayChangingHandler implements ServerTickEvents.StartTick {
 
             // The precipitation mixin reads this on both sides. The server half is set here rather
             // than read back from SeasonData, so the hot path never touches persistent state.
-            SeasonSnow.setSubSeason(dayData.getMonth().getSubSeason());
+            CurrentSeason.set(dayData.getMonth().getSubSeason());
 
             server.getPlayerManager().getPlayerList().forEach(player -> {
                 DayData.setPlayerDayData((IEntityDataSaver) player, dayData);

--- a/src/main/java/net/abakath/rpg4fools/server/events/SeasonPlantingGate.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/SeasonPlantingGate.java
@@ -1,0 +1,77 @@
+package net.abakath.rpg4fools.server.events;
+
+import net.abakath.rpg4fools.enums.Season;
+import net.abakath.rpg4fools.world.CropItems;
+import net.abakath.rpg4fools.world.CropSeasons;
+import net.abakath.rpg4fools.world.CurrentSeason;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.world.World;
+
+import java.util.Optional;
+
+/**
+ * Refuses to plant a crop outside the seasons it grows in.
+ *
+ * <p>Registered on both sides rather than server only. The client predicts placement, so a
+ * server-only refusal would show the crop appearing and then snapping away.
+ */
+public class SeasonPlantingGate {
+  public static void register() {
+    UseBlockCallback.EVENT.register(SeasonPlantingGate::onUseBlock);
+  }
+
+  private static ActionResult onUseBlock(PlayerEntity player, World world, Hand hand, BlockHitResult hit) {
+    ItemStack stack = player.getStackInHand(hand);
+    Season season = CurrentSeason.season();
+
+    Optional<BlockState> planted = CropItems.plantedBy(stack);
+    if (planted.isPresent()) {
+      BlockState crop = planted.get();
+
+      return CropSeasons.isInSeason(crop, season)
+              ? ActionResult.PASS
+              : refuse(player, world, crop, season, "message.rpg4fools.cannot_plant");
+    }
+
+    // Bone meal is the other way to make a crop grow, so leaving it alone would make out of season
+    // wheat merely slower to force rather than impossible.
+    if (stack.isOf(Items.BONE_MEAL)) {
+      BlockState target = world.getBlockState(hit.getBlockPos());
+
+      if (CropSeasons.isCrop(target) && !CropSeasons.isInSeason(target, season)) {
+        return refuse(player, world, target, season, "message.rpg4fools.cannot_grow");
+      }
+    }
+
+    return ActionResult.PASS;
+  }
+
+  /**
+   * Cancels the interaction, and says why on the action bar.
+   *
+   * <p>The message is sent from the server side only. Both sides run this handler, and the client
+   * copy would otherwise print the same line a second time.
+   */
+  private static ActionResult refuse(PlayerEntity player, World world, BlockState crop, Season season, String key) {
+    if (!world.isClient()) {
+      player.sendMessage(
+              Text.translatable(
+                      key,
+                      crop.getBlock().getName(),
+                      Text.literal(season.getName()).formatted(season.getColor())
+              ),
+              true
+      );
+    }
+
+    return ActionResult.FAIL;
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/world/CropItems.java
+++ b/src/main/java/net/abakath/rpg4fools/world/CropItems.java
@@ -27,6 +27,23 @@ import java.util.Optional;
 public class CropItems {
   private static final Map<Item, Block> PRODUCE = createProduce();
 
+  /**
+   * The crop this item would plant, or empty if placing it does not plant a crop.
+   *
+   * <p>Narrower than {@link #cropFor} on purpose. That one maps produce as well, and produce is not
+   * a seed: Items.PUMPKIN maps to the stem that grew it, so gating placement on it would refuse a
+   * pumpkin block as though it were a crop being sown.
+   */
+  public static Optional<BlockState> plantedBy(ItemStack stack) {
+    if (!(stack.getItem() instanceof BlockItem blockItem)) {
+      return Optional.empty();
+    }
+
+    BlockState planted = blockItem.getBlock().getDefaultState();
+
+    return CropSeasons.isCrop(planted) ? Optional.of(planted) : Optional.empty();
+  }
+
   /** The crop this item belongs to, or empty if the item has nothing to do with farming. */
   public static Optional<BlockState> cropFor(ItemStack stack) {
     Item item = stack.getItem();

--- a/src/main/java/net/abakath/rpg4fools/world/CurrentSeason.java
+++ b/src/main/java/net/abakath/rpg4fools/world/CurrentSeason.java
@@ -1,0 +1,36 @@
+package net.abakath.rpg4fools.world;
+
+import net.abakath.rpg4fools.enums.Season;
+import net.abakath.rpg4fools.enums.SubSeason;
+
+/**
+ * The season currently in effect.
+ *
+ * <p>Held statically rather than passed around because both sides need it and neither has a handle
+ * on the other's season state: the server owns SeasonData, the client owns ClientSeasonState. Both
+ * write here. In single player they share a JVM and write the same value, which is harmless.
+ *
+ * <p>Kept out of persistent state on purpose. Callers include block random ticks and player
+ * interactions, where the answer has to cost a single volatile read.
+ */
+public final class CurrentSeason {
+  private static volatile SubSeason subSeason = SubSeason.EARLY_SPRING;
+
+  private CurrentSeason() {
+  }
+
+  public static void set(SubSeason current) {
+    if (current != null) {
+      subSeason = current;
+    }
+  }
+
+  public static SubSeason get() {
+    return subSeason;
+  }
+
+  /** The parent season, for anything comparing against per-season crop tags. */
+  public static Season season() {
+    return subSeason.getSeason();
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/world/SeasonSnow.java
+++ b/src/main/java/net/abakath/rpg4fools/world/SeasonSnow.java
@@ -9,9 +9,8 @@ import net.abakath.rpg4fools.enums.SubSeason;
  * the client for weather rendering, so the lookup is deliberately a single volatile read and one
  * float comparison.
  *
- * <p>Held statically rather than passed around because both sides need it and neither has a handle
- * on the other's season state: the server owns SeasonData, the client owns ClientSeasonState. Both
- * write here. In single player they share a JVM and write the same value, which is harmless.
+ * <p>The season itself lives in {@link CurrentSeason}; this class only answers what that season
+ * does to snow.
  */
 public final class SeasonSnow {
   /**
@@ -20,19 +19,7 @@ public final class SeasonSnow {
    */
   private static final float VANILLA_SNOW_TEMPERATURE = 0.15f;
 
-  private static volatile SubSeason subSeason = SubSeason.EARLY_SPRING;
-
   private SeasonSnow() {
-  }
-
-  public static void setSubSeason(SubSeason current) {
-    if (current != null) {
-      subSeason = current;
-    }
-  }
-
-  public static SubSeason getSubSeason() {
-    return subSeason;
   }
 
   /**
@@ -43,7 +30,7 @@ public final class SeasonSnow {
    * and is deliberately above every value here.
    */
   public static float snowLineTemperature() {
-    return switch (subSeason) {
+    return switch (CurrentSeason.get()) {
       case LATE_AUTUMN -> 0.30f;
       case EARLY_WINTER -> 0.60f;
       case MID_WINTER -> 0.90f;
@@ -75,7 +62,7 @@ public final class SeasonSnow {
    * cover for a month reads as a thaw; frozen peaks doing the same would just look broken.
    */
   public static boolean shouldThaw(float biomeTemperature) {
-    if (subSeason == SubSeason.MID_SUMMER) {
+    if (CurrentSeason.get() == SubSeason.MID_SUMMER) {
       return biomeTemperature > PERMAFROST_TEMPERATURE;
     }
 
@@ -91,6 +78,6 @@ public final class SeasonSnow {
    * the intent, draining a frozen ocean is not.
    */
   public static boolean isMidsummerThaw() {
-    return subSeason == SubSeason.MID_SUMMER;
+    return CurrentSeason.get() == SubSeason.MID_SUMMER;
   }
 }

--- a/src/main/resources/assets/rpg4fools/lang/en_us.json
+++ b/src/main/resources/assets/rpg4fools/lang/en_us.json
@@ -1,4 +1,6 @@
 {
+  "message.rpg4fools.cannot_grow": "%s cannot grow in %s",
+  "message.rpg4fools.cannot_plant": "%s cannot be planted in %s",
   "tooltip.rpg4fools.hold_shift": "Hold Shift for seasons",
   "tooltip.rpg4fools.seasons": "Seasons: %s"
 }


### PR DESCRIPTION
First of three PRs for season-driven crop behaviour. This one only blocks planting — nothing dies yet.

## Behaviour

- Right-clicking to plant a crop outside its seasons is cancelled, and the action bar says `Wheat cannot be planted in Winter`, season name in its own colour.
- Bone meal on an out-of-season crop is refused too (`Wheat cannot grow in Winter`). It's the other growth path; leaving it open would make winter wheat slower to force rather than impossible.
- Existing crops keep growing. Dying is PR 2.

## Seeds vs produce

Gating uses a new `CropItems.plantedBy(stack)` — `BlockItem`s only, kept if the block they place is in `#rpg4fools:crops`. The existing `cropFor` deliberately maps *produce* as well, and `Items.PUMPKIN` maps to `PUMPKIN_STEM`, so gating on it would have refused placing a **pumpkin block** in winter. Two resolvers, two questions.

## Both sides

`UseBlockCallback` is registered commonly. The client predicts placement, so a server-only refusal shows the crop appearing and snapping away. The message is sent only when `!world.isClient()`, or it prints twice in single player.

## Refactor included

Season state moves from `SeasonSnow` into a new `world/CurrentSeason.java`. Crop code and snow code both need "what season is it", and reading that from `SeasonSnow` would read like a bug; `SeasonSnow` keeps only the question of what the season does to snow. Callers updated: `DayChangingHandler`, `ClientSeasonState`. PR 2's random-tick hook needs the same holder.

## Verification

CI compile only — no JDK in the environment this was written in. `runClient` checks worth doing:

- plant wheat in winter → refused, message shown
- plant wheat in spring → works
- bone meal an out-of-season crop → refused
- place a **pumpkin block** in winter → allowed (the seeds/produce distinction)
- single player: message appears once, not twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)