### PR TITLE
Out-of-season crops die

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/RPG4Fools.java
+++ b/src/main/java/net/abakath/rpg4fools/RPG4Fools.java
@@ -1,5 +1,6 @@
 package net.abakath.rpg4fools;
 
+import net.abakath.rpg4fools.init.ModBlocks;
 import net.abakath.rpg4fools.init.ModEvents;
 import net.abakath.rpg4fools.init.ModMessages;
 import net.fabricmc.api.ModInitializer;
@@ -14,6 +15,7 @@ public class RPG4Fools implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
+		ModBlocks.registerBlocks();
 		ModEvents.registerEvents();
 		ModMessages.registerS2CPackets();
 	}

--- a/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
+++ b/src/main/java/net/abakath/rpg4fools/RPG4FoolsClient.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools;
 
 import net.abakath.rpg4fools.client.ClientModMessages;
 import net.abakath.rpg4fools.client.CropSeasonTooltip;
+import net.abakath.rpg4fools.client.ModBlockRenderers;
 import net.abakath.rpg4fools.client.SeasonAtmosphere;
 import net.abakath.rpg4fools.client.SeasonColorProviders;
 import net.abakath.rpg4fools.client.SeasonsHudOverlay;
@@ -17,6 +18,7 @@ public class RPG4FoolsClient implements ClientModInitializer {
     ClientModMessages.registerS2CReceivers();
     SeasonColorProviders.register();
     CropSeasonTooltip.register();
+    ModBlockRenderers.register();
 
     // Biome tags arrive as part of the join handshake. Anything resolved before they land falls
     // back to DEFAULT, and the atmosphere memoises per registry entry, so that wrong answer would

--- a/src/main/java/net/abakath/rpg4fools/client/ModBlockRenderers.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ModBlockRenderers.java
@@ -1,0 +1,24 @@
+package net.abakath.rpg4fools.client;
+
+import net.abakath.rpg4fools.init.ModBlocks;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.minecraft.client.render.RenderLayer;
+
+/**
+ * Render layers for the mod's blocks.
+ *
+ * <p>A cross model needs the cutout layer. Without this the block renders on the solid layer and
+ * the transparent part of the texture comes out black, which looks like a broken texture rather
+ * than a missing line of registration.
+ */
+@Environment(EnvType.CLIENT)
+public final class ModBlockRenderers {
+  private ModBlockRenderers() {
+  }
+
+  public static void register() {
+    BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.DEAD_CROP, RenderLayer.getCutout());
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/init/ModBlocks.java
+++ b/src/main/java/net/abakath/rpg4fools/init/ModBlocks.java
@@ -1,0 +1,43 @@
+package net.abakath.rpg4fools.init;
+
+import net.abakath.rpg4fools.RPG4Fools;
+import net.abakath.rpg4fools.world.DeadCropBlock;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.piston.PistonBehavior;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.util.Identifier;
+
+/**
+ * Blocks the mod adds.
+ *
+ * <p>None of them get a BlockItem. They are not things a player collects or places; the season hook
+ * is the only thing that puts them in the world.
+ */
+public class ModBlocks {
+  public static final Block DEAD_CROP = register("dead_crop", new DeadCropBlock(
+          AbstractBlock.Settings.create()
+                  .breakInstantly()
+                  .noCollision()
+                  // No loot table of its own. A dead crop is a loss, not a harvest, and saying so
+                  // here avoids shipping an empty loot table file.
+                  .dropsNothing()
+                  .sounds(BlockSoundGroup.CROP)
+                  .pistonBehavior(PistonBehavior.DESTROY)
+  ));
+
+  private static Block register(String name, Block block) {
+    return Registry.register(Registries.BLOCK, new Identifier(RPG4Fools.MOD_ID, name), block);
+  }
+
+  /**
+   * Forces this class to load, which is what actually performs the registrations above.
+   *
+   * <p>Called from the mod initialiser. Without it the static fields would be initialised at some
+   * arbitrary first use, which for a block means after the registries have already frozen.
+   */
+  public static void registerBlocks() {
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/mixin/BlockStateRandomTickMixin.java
+++ b/src/main/java/net/abakath/rpg4fools/mixin/BlockStateRandomTickMixin.java
@@ -1,0 +1,55 @@
+package net.abakath.rpg4fools.mixin;
+
+import net.abakath.rpg4fools.init.ModBlocks;
+import net.abakath.rpg4fools.world.CropSeasons;
+import net.abakath.rpg4fools.world.CurrentSeason;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Kills crops whose season has passed.
+ *
+ * <p>Injected here rather than into each crop class because every growing block passes through this
+ * one method, so modded crops die on the same rule as vanilla ones and there is a single target
+ * string to get right instead of five.
+ *
+ * <p>This is the hottest block path in the game. The first line is a tag lookup, which is a set
+ * membership test against the block's registry entry, and every block that is not a crop pays only
+ * that.
+ *
+ * <p>Death is deliberately lazy: a crop dies on the next random tick it would have grown on. Chunks
+ * only random tick near players, so a distant farm converts when someone comes back to it. The
+ * season change itself costs nothing and nothing walks the world looking for work.
+ */
+@Mixin(AbstractBlock.AbstractBlockState.class)
+public class BlockStateRandomTickMixin {
+  @Inject(method = "randomTick", at = @At("HEAD"), cancellable = true)
+  private void rpg4fools$killOutOfSeasonCrops(ServerWorld world, BlockPos pos, Random random, CallbackInfo info) {
+    BlockState state = (BlockState) (Object) this;
+
+    if (!CropSeasons.isCrop(state)) {
+      return;
+    }
+
+    // Berry bushes are in the crops tag but are not supposed to die; they go dormant instead, which
+    // is a later change. Until then they keep growing rather than being killed by this hook.
+    if (state.isOf(Blocks.SWEET_BERRY_BUSH)) {
+      return;
+    }
+
+    if (CropSeasons.isInSeason(state, CurrentSeason.season())) {
+      return;
+    }
+
+    world.setBlockState(pos, ModBlocks.DEAD_CROP.getDefaultState());
+    info.cancel();
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/world/DeadCropBlock.java
+++ b/src/main/java/net/abakath/rpg4fools/world/DeadCropBlock.java
@@ -1,0 +1,55 @@
+package net.abakath.rpg4fools.world;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.PlantBlock;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+
+/**
+ * What a crop leaves behind when its season ends.
+ *
+ * <p>One block for every crop. A dead melon stem and a dead carrot are the same thing to a player:
+ * something to clear before replanting, worth nothing.
+ *
+ * <p>It never grows back and it never spreads. The random tick hook only looks at blocks in the
+ * crops tag and this block is deliberately outside it, so nothing ever examines it again. Breaking
+ * it is the only way it leaves the world.
+ */
+public class DeadCropBlock extends PlantBlock {
+  public static final MapCodec<DeadCropBlock> CODEC = createCodec(DeadCropBlock::new);
+
+  /** Low and narrow, like the withered crop it replaced rather than a full block of shrub. */
+  private static final VoxelShape SHAPE = Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 13.0, 14.0);
+
+  public DeadCropBlock(Settings settings) {
+    super(settings);
+  }
+
+  @Override
+  protected MapCodec<DeadCropBlock> getCodec() {
+    return CODEC;
+  }
+
+  @Override
+  public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+    return SHAPE;
+  }
+
+  /**
+   * Stands on dirt as readily as on farmland.
+   *
+   * <p>A crop pops off the moment its farmland reverts to dirt. Doing the same here would let a
+   * player clear a dead field by trampling it, which is the opposite of leaving them something to
+   * break.
+   */
+  @Override
+  protected boolean canPlantOnTop(BlockState floor, BlockView world, BlockPos pos) {
+    return floor.isOf(Blocks.FARMLAND) || floor.isIn(BlockTags.DIRT);
+  }
+}

--- a/src/main/resources/assets/rpg4fools/blockstates/dead_crop.json
+++ b/src/main/resources/assets/rpg4fools/blockstates/dead_crop.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "rpg4fools:block/dead_crop"
+    }
+  }
+}

--- a/src/main/resources/assets/rpg4fools/models/block/dead_crop.json
+++ b/src/main/resources/assets/rpg4fools/models/block/dead_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cross",
+  "textures": {
+    "cross": "minecraft:block/dead_bush"
+  }
+}

--- a/src/main/resources/rpg4fools.mixins.json
+++ b/src/main/resources/rpg4fools.mixins.json
@@ -3,9 +3,10 @@
   "package": "net.abakath.rpg4fools.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "BiomePrecipitationMixin",
+    "BlockStateRandomTickMixin",
     "ModEntityDataSaverMixin",
-    "RPG4FoolsMixin",
-    "BiomePrecipitationMixin"
+    "RPG4FoolsMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Second of three PRs. **Targets `feat/season-planting-gate` (#42), not `release/0.3.0`** — it needs `CurrentSeason` from that PR. Merge #42 first and I'll retarget this to the release branch.

## Behaviour

A crop whose season has passed becomes `rpg4fools:dead_crop`: drops nothing, never grows, never comes back. Breaking it is the only way it leaves the world.

One block for every crop — a dead melon stem and a dead carrot mean the same thing to a player.

## Why the hook is where it is

`AbstractBlock.AbstractBlockState#randomTick`, HEAD, cancellable. Every growing block passes through it, so modded crops obey the same rule as vanilla ones and there's one target string to get right instead of five (`CropBlock`, `StemBlock`, `TorchflowerBlock`, `PitcherCropBlock`, …).

It is also the hottest block path in the game. The first line is `CropSeasons.isCrop(state)` — a set membership test on the block's registry entry — and every non-crop block pays only that.

## Why dying is lazy

A crop dies on the tick it *would have grown* on. Chunks random-tick only near players, so a distant farm converts when someone returns to it. Nothing scans chunks and the season change itself costs nothing.

## The tag asymmetry

`dead_crop` is deliberately **outside** `#rpg4fools:crops`, so the hook never examines it again. "Stays dead until broken" falls out of tag membership rather than any stored flag. (PR 3's dormant bush goes *inside* the tag for the opposite reason — it must keep being examined to revive.)

## New plumbing

First block the mod has ever registered:

- `init/ModBlocks.java` — no `BlockItem`; only the hook creates this block.
- `world/DeadCropBlock.java` — `PlantBlock`, `breakInstantly`, `noCollision`, `dropsNothing()` instead of an empty loot table file (which would also have meant hand-writing a path under `loot_tables`, plural in 1.20.6 — the #41 mistake again). Stands on dirt as well as farmland, so trampling the farmland doesn't clear a dead field.
- `client/ModBlockRenderers.java` — cutout render layer. Without it a cross model renders on the solid layer and the transparent pixels come out black.
- `blockstates/dead_crop.json`, `models/block/dead_crop.json` → `minecraft:block/cross` + `minecraft:block/dead_bush`.

## Berry bushes

Skipped by identity in the hook. They're in the crops tag but aren't meant to die; PR 3 replaces the skip with dormancy.

## Verification

CI compiles mixins but does **not apply** them — a wrong target or descriptor passes CI and fails at launch. This one needs `runClient`:

- stand by a wheat farm across a season boundary → crops convert to dead crops
- break a dead crop → nothing drops
- dead crop is still there next spring
- no frame rate change in a normal world (the hot-path concern)
- melon/pumpkin: stem dies, an already-grown fruit survives
- berry bushes still grow and fruit normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)