### PR TITLE
Berry bushes go dormant instead of dying

### DIFF
--- a/src/main/generated/data/rpg4fools/tags/blocks/crops.json
+++ b/src/main/generated/data/rpg4fools/tags/blocks/crops.json
@@ -10,6 +10,7 @@
     "minecraft:pumpkin_stem",
     "minecraft:sweet_berry_bush",
     "minecraft:attached_melon_stem",
-    "minecraft:attached_pumpkin_stem"
+    "minecraft:attached_pumpkin_stem",
+    "rpg4fools:dormant_sweet_berry_bush"
   ]
 }

--- a/src/main/generated/data/rpg4fools/tags/blocks/grows_in_autumn.json
+++ b/src/main/generated/data/rpg4fools/tags/blocks/grows_in_autumn.json
@@ -6,6 +6,7 @@
     "minecraft:beetroots",
     "minecraft:pumpkin_stem",
     "minecraft:sweet_berry_bush",
-    "minecraft:attached_pumpkin_stem"
+    "minecraft:attached_pumpkin_stem",
+    "rpg4fools:dormant_sweet_berry_bush"
   ]
 }

--- a/src/main/generated/data/rpg4fools/tags/blocks/grows_in_summer.json
+++ b/src/main/generated/data/rpg4fools/tags/blocks/grows_in_summer.json
@@ -8,6 +8,7 @@
     "minecraft:pumpkin_stem",
     "minecraft:sweet_berry_bush",
     "minecraft:attached_melon_stem",
-    "minecraft:attached_pumpkin_stem"
+    "minecraft:attached_pumpkin_stem",
+    "rpg4fools:dormant_sweet_berry_bush"
   ]
 }

--- a/src/main/java/net/abakath/rpg4fools/client/ModBlockRenderers.java
+++ b/src/main/java/net/abakath/rpg4fools/client/ModBlockRenderers.java
@@ -19,6 +19,10 @@ public final class ModBlockRenderers {
   }
 
   public static void register() {
-    BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.DEAD_CROP, RenderLayer.getCutout());
+    BlockRenderLayerMap.INSTANCE.putBlocks(
+            RenderLayer.getCutout(),
+            ModBlocks.DEAD_CROP,
+            ModBlocks.DORMANT_SWEET_BERRY_BUSH
+    );
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
+++ b/src/main/java/net/abakath/rpg4fools/client/SeasonColorProviders.java
@@ -1,5 +1,6 @@
 package net.abakath.rpg4fools.client;
 
+import net.abakath.rpg4fools.init.ModBlocks;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
@@ -31,6 +32,12 @@ public final class SeasonColorProviders {
   private static final int SPRUCE_FOLIAGE_COLOR = 0x619961;
   private static final int MANGROVE_FOLIAGE_COLOR = 0x92C648;
   private static final int LILY_PAD_COLOR = 0x208030;
+
+  /**
+   * Brown for a dormant berry bush. Not season graded: the bush is brown because it is dormant, and
+   * letting the season shift that colour would blur the one signal the block exists to give.
+   */
+  private static final int DORMANT_BUSH_COLOR = 0x7A6338;
 
   /** Blocks vanilla tints from the biome grass colour. */
   private static final Block[] GRASS_BLOCKS = {
@@ -65,7 +72,19 @@ public final class SeasonColorProviders {
   public static void register() {
     registerBiomeTintedBlocks();
     registerFixedColorBlocks();
+    registerDormantBush();
     registerItems();
+  }
+
+  /**
+   * The dormant bush reuses the vanilla bush texture and browns it, rather than shipping art or
+   * borrowing the dead bush sprite, which would make it indistinguishable from a dead crop.
+   */
+  private static void registerDormantBush() {
+    ColorProviderRegistry.BLOCK.register(
+            (state, world, pos, tintIndex) -> tintIndex == TINTED_LAYER ? DORMANT_BUSH_COLOR : -1,
+            ModBlocks.DORMANT_SWEET_BERRY_BUSH
+    );
   }
 
   private static void registerBiomeTintedBlocks() {

--- a/src/main/java/net/abakath/rpg4fools/datagen/SeasonCropTagProvider.java
+++ b/src/main/java/net/abakath/rpg4fools/datagen/SeasonCropTagProvider.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools.datagen;
 
 import net.abakath.rpg4fools.enums.Season;
 import net.abakath.rpg4fools.init.ModBlockTags;
+import net.abakath.rpg4fools.init.ModBlocks;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
 import net.minecraft.block.Block;
@@ -72,6 +73,10 @@ public class SeasonCropTagProvider extends FabricTagProvider.BlockTagProvider {
     // both halves of one melon patch.
     put(seasons, Blocks.ATTACHED_MELON_STEM, Season.SUMMER);
     put(seasons, Blocks.ATTACHED_PUMPKIN_STEM, Season.SUMMER, Season.AUTUMN);
+
+    // The dormant bush keeps the live bush's seasons. The hook reads them to decide when to revive
+    // it, and an untagged block reads as growing in every season, which would revive it in winter.
+    put(seasons, ModBlocks.DORMANT_SWEET_BERRY_BUSH, Season.SUMMER, Season.AUTUMN);
 
     return seasons;
   }

--- a/src/main/java/net/abakath/rpg4fools/init/ModBlocks.java
+++ b/src/main/java/net/abakath/rpg4fools/init/ModBlocks.java
@@ -2,6 +2,7 @@ package net.abakath.rpg4fools.init;
 
 import net.abakath.rpg4fools.RPG4Fools;
 import net.abakath.rpg4fools.world.DeadCropBlock;
+import net.abakath.rpg4fools.world.DormantSweetBerryBushBlock;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.piston.PistonBehavior;
@@ -25,6 +26,21 @@ public class ModBlocks {
                   // here avoids shipping an empty loot table file.
                   .dropsNothing()
                   .sounds(BlockSoundGroup.CROP)
+                  .pistonBehavior(PistonBehavior.DESTROY)
+  ));
+
+  /**
+   * The off season form of a sweet berry bush. Sits in the crops tag, unlike DEAD_CROP, because the
+   * season hook has to keep looking at it: that hook is the only thing that can revive it.
+   */
+  public static final Block DORMANT_SWEET_BERRY_BUSH = register("dormant_sweet_berry_bush", new DormantSweetBerryBushBlock(
+          AbstractBlock.Settings.create()
+                  // Still ticks. Revival is decided at the head of the random tick, so a block that
+                  // stopped ticking would never come back.
+                  .ticksRandomly()
+                  .noCollision()
+                  .dropsNothing()
+                  .sounds(BlockSoundGroup.SWEET_BERRY_BUSH)
                   .pistonBehavior(PistonBehavior.DESTROY)
   ));
 

--- a/src/main/java/net/abakath/rpg4fools/mixin/BlockStateRandomTickMixin.java
+++ b/src/main/java/net/abakath/rpg4fools/mixin/BlockStateRandomTickMixin.java
@@ -6,6 +6,7 @@ import net.abakath.rpg4fools.world.CurrentSeason;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.SweetBerryBushBlock;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
@@ -39,13 +40,30 @@ public class BlockStateRandomTickMixin {
       return;
     }
 
-    // Berry bushes are in the crops tag but are not supposed to die; they go dormant instead, which
-    // is a later change. Until then they keep growing rather than being killed by this hook.
+    boolean inSeason = CropSeasons.isInSeason(state, CurrentSeason.season());
+
+    // Bushes are the one crop that comes back, so they swap between two blocks instead of dying.
     if (state.isOf(Blocks.SWEET_BERRY_BUSH)) {
+      if (!inSeason) {
+        world.setBlockState(pos, ModBlocks.DORMANT_SWEET_BERRY_BUSH.getDefaultState());
+        info.cancel();
+      }
+
       return;
     }
 
-    if (CropSeasons.isInSeason(state, CurrentSeason.season())) {
+    if (state.isOf(ModBlocks.DORMANT_SWEET_BERRY_BUSH)) {
+      if (inSeason) {
+        // Age 1 is leafy with no fruit, so the bush picks up where a fresh one would rather than
+        // handing back the berries it lost going dormant.
+        world.setBlockState(pos, Blocks.SWEET_BERRY_BUSH.getDefaultState().with(SweetBerryBushBlock.AGE, 1));
+      }
+
+      info.cancel();
+      return;
+    }
+
+    if (inSeason) {
       return;
     }
 

--- a/src/main/java/net/abakath/rpg4fools/world/DormantSweetBerryBushBlock.java
+++ b/src/main/java/net/abakath/rpg4fools/world/DormantSweetBerryBushBlock.java
@@ -1,0 +1,71 @@
+package net.abakath.rpg4fools.world;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SweetBerryBushBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldView;
+
+/**
+ * A sweet berry bush waiting out a season it cannot fruit in.
+ *
+ * <p>Unlike every other crop a bush does not die, so this is a state it comes back from rather than
+ * an ending. The season hook swaps the two blocks in both directions.
+ *
+ * <p>Extends the vanilla bush to keep its shape, its slowdown and its thorns: a dormant bush is
+ * still a thicket to walk through. Only the parts that amount to producing berries are turned off.
+ */
+public class DormantSweetBerryBushBlock extends SweetBerryBushBlock {
+  /**
+   * Typed to the parent block, because that is what SweetBerryBushBlock.getCodec returns and the
+   * return type is invariant. The factory still builds dormant bushes; only the declared type is
+   * the parent's.
+   */
+  public static final MapCodec<SweetBerryBushBlock> CODEC = createCodec(DormantSweetBerryBushBlock::new);
+
+  public DormantSweetBerryBushBlock(Settings settings) {
+    super(settings);
+  }
+
+  @Override
+  public MapCodec<SweetBerryBushBlock> getCodec() {
+    return CODEC;
+  }
+
+  /**
+   * Never grows on its own.
+   *
+   * <p>The block still random ticks, and deliberately so: the season hook runs at the head of the
+   * same tick and is the only thing that can bring the bush back. A block that stopped ticking
+   * would stay dormant forever.
+   */
+  @Override
+  public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
+  }
+
+  @Override
+  public boolean isFertilizable(WorldView world, BlockPos pos, BlockState state) {
+    return false;
+  }
+
+  @Override
+  public boolean canGrow(World world, Random random, BlockPos pos, BlockState state) {
+    return false;
+  }
+
+  @Override
+  public void grow(ServerWorld world, Random random, BlockPos pos, BlockState state) {
+  }
+
+  /** Nothing to pick. Vanilla would hand over berries and reset the age. */
+  @Override
+  public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
+    return ActionResult.PASS;
+  }
+}

--- a/src/main/resources/assets/rpg4fools/blockstates/dormant_sweet_berry_bush.json
+++ b/src/main/resources/assets/rpg4fools/blockstates/dormant_sweet_berry_bush.json
@@ -1,0 +1,16 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "rpg4fools:block/dormant_sweet_berry_bush"
+    },
+    "age=1": {
+      "model": "rpg4fools:block/dormant_sweet_berry_bush"
+    },
+    "age=2": {
+      "model": "rpg4fools:block/dormant_sweet_berry_bush"
+    },
+    "age=3": {
+      "model": "rpg4fools:block/dormant_sweet_berry_bush"
+    }
+  }
+}

--- a/src/main/resources/assets/rpg4fools/models/block/dormant_sweet_berry_bush.json
+++ b/src/main/resources/assets/rpg4fools/models/block/dormant_sweet_berry_bush.json
@@ -1,0 +1,29 @@
+{
+  "ambientocclusion": false,
+  "textures": {
+    "particle": "minecraft:block/sweet_berry_bush_stage1",
+    "cross": "minecraft:block/sweet_berry_bush_stage1"
+  },
+  "elements": [
+    {
+      "from": [0.8, 0, 8],
+      "to": [15.2, 16, 8],
+      "rotation": { "origin": [8, 8, 8], "axis": "y", "angle": 45, "rescale": true },
+      "shade": false,
+      "faces": {
+        "north": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 },
+        "south": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 }
+      }
+    },
+    {
+      "from": [8, 0, 0.8],
+      "to": [8, 16, 15.2],
+      "rotation": { "origin": [8, 8, 8], "axis": "y", "angle": -45, "rescale": true },
+      "shade": false,
+      "faces": {
+        "north": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 },
+        "south": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Third of three PRs. **Targets `feat/dead-crops` (#43)** — it replaces the berry-bush skip that PR left in the season hook. Merge #42 then #43 and I'll retarget.

## Behaviour

A sweet berry bush out of season browns, stops producing, stops growing — and does **not** die. When its season returns it revives at age 1: leafy, no berries, growing from there. Berries it was carrying when dormancy hit are lost.

## The block

`DormantSweetBerryBushBlock extends SweetBerryBushBlock`, so it keeps the vanilla shape, slowdown and thorn damage — a dormant bush is still a thicket. Only berry production is turned off: `randomTick` no-op, `isFertilizable`/`canGrow` false, `onUse` no longer harvests. `dropsNothing()`.

It still **random-ticks on purpose**: the season hook runs at the head of that same tick and is the only thing that can revive it. A block that stopped ticking would stay dormant forever.

The inherited `AGE` property comes along, so the blockstate maps all four ages to one model and conversion sets age 0.

## Tag membership is the mechanism

| Block | In `#rpg4fools:crops`? | Consequence |
|---|---|---|
| `dead_crop` | no | hook never examines it → stays dead until broken |
| `dormant_sweet_berry_bush` | **yes** | hook keeps examining it → revives when its season returns |

Neither behaviour uses a stored flag. The dormant bush also carries the live bush's seasons (summer, autumn) — an untagged block reads as "grows in every season" under `CropSeasons`' permissive fallback, which would revive it in winter.

## Appearance

Own model: vanilla cross geometry with `tintindex: 0`, `minecraft:block/sweet_berry_bush_stage1` texture, plus a flat brown registered in `SeasonColorProviders`. Reusing `minecraft:block/dead_bush` would have made it indistinguishable from `dead_crop`. The brown is deliberately *not* season-graded like the foliage tints — the bush is brown because it's dormant, and grading it would blur that signal.

## Verification

CI compile only. Two things I'd watch for specifically at `runClient`, both of which CI cannot see:

- The overridden signatures on `SweetBerryBushBlock` (`onUse`, `isFertilizable`, `canGrow`, `randomTick`) are the 1.20.6 shapes — a compile error here is the *good* outcome; silent behaviour loss would be worse. If it compiles, they're right.
- The tint only applies because the model declares `tintindex: 0`. If the bush renders un-browned, that's the model, not the provider.

Also worth checking: bush browns at the boundary, produces nothing while dormant, revives leafy when its season returns, and thorns still hurt while dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)