### PR TITLE
Say why a crop cannot be planted

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/server/events/SeasonPlantingGate.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/SeasonPlantingGate.java
@@ -57,20 +57,23 @@ public class SeasonPlantingGate {
   /**
    * Cancels the interaction, and says why on the action bar.
    *
-   * <p>The message is sent from the server side only. Both sides run this handler, and the client
-   * copy would otherwise print the same line a second time.
+   * <p>Sent from whichever side is running, which in practice means the client. Fabric only
+   * forwards a use to the server when the callback returns SUCCESS, so a FAIL from the client
+   * copy of this handler ends the interaction there and the server copy is never invoked. Guarding
+   * the message on the server side left it unreachable: the block was refused and nothing was said.
+   *
+   * <p>That also means it cannot print twice. Whichever side refuses first is the only side that
+   * gets to run.
    */
   private static ActionResult refuse(PlayerEntity player, World world, BlockState crop, Season season, String key) {
-    if (!world.isClient()) {
-      player.sendMessage(
-              Text.translatable(
-                      key,
-                      crop.getBlock().getName(),
-                      Text.literal(season.getName()).formatted(season.getColor())
-              ),
-              true
-      );
-    }
+    player.sendMessage(
+            Text.translatable(
+                    key,
+                    crop.getBlock().getName(),
+                    Text.literal(season.getName()).formatted(season.getColor())
+            ),
+            true
+    );
 
     return ActionResult.FAIL;
   }


### PR DESCRIPTION
Reported: planting is refused, but no message appears. Same for bone meal, and for berry bushes.

## Root cause

One bug, one code path. From Fabric's own `ClientPlayerInteractionManagerMixin` (`1.20.6`):

```java
ActionResult result = UseBlockCallback.EVENT.invoker().interact(player, player.getWorld(), hand, blockHitResult);

if (result != ActionResult.PASS) {
    if (result == ActionResult.SUCCESS) {
        sendSequencedPacket(...);   // only SUCCESS sends the interaction packet
    }
    info.setReturnValue(result);
}
```

The client copy of the handler returns `FAIL`, so no interaction packet is sent, so the **server copy never runs** — and the message was guarded by `if (!world.isClient())`. The refusal working and the message not appearing have the same cause: the client cancel is what makes the block work, and it is also what swallows the message.

## Fix

Send from whichever side is running. In practice that is the client. It still cannot print twice: whichever side refuses first is the only side that gets to run, and the loser is never invoked.

## Verification

CI compile only. In game: plant an out-of-season seed, bone meal an out-of-season crop, and bone meal an out-of-season berry bush — each should now show a line on the action bar, once.

One thing I could not check from here: this relies on `ClientPlayerEntity` implementing `sendMessage(Text, boolean)` as an overlay message. If the action bar stays empty in game, the fallback is a client-only helper calling `InGameHud.setOverlayMessage` directly, and I'd want to know rather than guess.

Targets `feat/dormant-berry-bush` (#44) so it applies on top of the full feature set. #42/#43/#44 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)