### PR TITLE
Kill out-of-season crops the moment the season turns

### DIFF
--- a/src/main/java/net/abakath/rpg4fools/init/ModEvents.java
+++ b/src/main/java/net/abakath/rpg4fools/init/ModEvents.java
@@ -1,6 +1,7 @@
 package net.abakath.rpg4fools.init;
 
 
+import net.abakath.rpg4fools.server.LoadedChunks;
 import net.abakath.rpg4fools.server.events.CropTagValidator;
 import net.abakath.rpg4fools.server.events.DayChangingHandler;
 import net.abakath.rpg4fools.server.events.SeasonPlantingGate;
@@ -12,6 +13,7 @@ public class ModEvents {
     ServerTickEvents.START_SERVER_TICK.register(new DayChangingHandler());
     ServerTickEvents.START_SERVER_TICK.register(new SnowMeltHandler());
 
+    LoadedChunks.register();
     CropTagValidator.register();
     SeasonPlantingGate.register();
   }

--- a/src/main/java/net/abakath/rpg4fools/mixin/BlockStateRandomTickMixin.java
+++ b/src/main/java/net/abakath/rpg4fools/mixin/BlockStateRandomTickMixin.java
@@ -1,12 +1,9 @@
 package net.abakath.rpg4fools.mixin;
 
-import net.abakath.rpg4fools.init.ModBlocks;
-import net.abakath.rpg4fools.world.CropSeasons;
+import net.abakath.rpg4fools.world.CropTransition;
 import net.abakath.rpg4fools.world.CurrentSeason;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.SweetBerryBushBlock;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
@@ -16,58 +13,30 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Kills crops whose season has passed.
+ * Catches crops the season change could not reach.
+ *
+ * <p>SeasonChangeSweep settles everything loaded the moment a season turns. This is for the rest: a
+ * farm nobody had loaded at the time converts on its first random tick instead, and out of season
+ * growth is cancelled in the same breath.
  *
  * <p>Injected here rather than into each crop class because every growing block passes through this
- * one method, so modded crops die on the same rule as vanilla ones and there is a single target
- * string to get right instead of five.
+ * one method, so modded crops obey the same rule as vanilla ones and there is a single target string
+ * to get right instead of five.
  *
- * <p>This is the hottest block path in the game. The first line is a tag lookup, which is a set
- * membership test against the block's registry entry, and every block that is not a crop pays only
- * that.
- *
- * <p>Death is deliberately lazy: a crop dies on the next random tick it would have grown on. Chunks
- * only random tick near players, so a distant farm converts when someone comes back to it. The
- * season change itself costs nothing and nothing walks the world looking for work.
+ * <p>This is the hottest block path in the game. CropTransition opens with a crops tag lookup, which
+ * is a set membership test against the block's registry entry, and every block that is not a crop
+ * pays only that.
  */
 @Mixin(AbstractBlock.AbstractBlockState.class)
 public class BlockStateRandomTickMixin {
   @Inject(method = "randomTick", at = @At("HEAD"), cancellable = true)
-  private void rpg4fools$killOutOfSeasonCrops(ServerWorld world, BlockPos pos, Random random, CallbackInfo info) {
+  private void rpg4fools$settleOutOfSeasonCrops(ServerWorld world, BlockPos pos, Random random, CallbackInfo info) {
     BlockState state = (BlockState) (Object) this;
 
-    if (!CropSeasons.isCrop(state)) {
-      return;
-    }
-
-    boolean inSeason = CropSeasons.isInSeason(state, CurrentSeason.season());
-
-    // Bushes are the one crop that comes back, so they swap between two blocks instead of dying.
-    if (state.isOf(Blocks.SWEET_BERRY_BUSH)) {
-      if (!inSeason) {
-        world.setBlockState(pos, ModBlocks.DORMANT_SWEET_BERRY_BUSH.getDefaultState());
-        info.cancel();
-      }
-
-      return;
-    }
-
-    if (state.isOf(ModBlocks.DORMANT_SWEET_BERRY_BUSH)) {
-      if (inSeason) {
-        // Age 1 is leafy with no fruit, so the bush picks up where a fresh one would rather than
-        // handing back the berries it lost going dormant.
-        world.setBlockState(pos, Blocks.SWEET_BERRY_BUSH.getDefaultState().with(SweetBerryBushBlock.AGE, 1));
-      }
-
+    // Cancelled only when the block was replaced. Whatever is standing there now is not the block
+    // vanilla was about to grow.
+    if (CropTransition.apply(world, pos, state, CurrentSeason.season())) {
       info.cancel();
-      return;
     }
-
-    if (inSeason) {
-      return;
-    }
-
-    world.setBlockState(pos, ModBlocks.DEAD_CROP.getDefaultState());
-    info.cancel();
   }
 }

--- a/src/main/java/net/abakath/rpg4fools/server/LoadedChunks.java
+++ b/src/main/java/net/abakath/rpg4fools/server/LoadedChunks.java
@@ -1,0 +1,62 @@
+package net.abakath.rpg4fools.server;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.WorldChunk;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Which chunks are loaded, per world.
+ *
+ * <p>Needed because nothing public hands out that list: ServerChunkManager will look a chunk up by
+ * position but will not enumerate what it holds. Keeping the positions as they load is cheaper than
+ * reaching into its internals through a mixin, and it is the only way to act on every loaded chunk
+ * at a specific moment.
+ *
+ * <p>Positions rather than chunk objects, so a missed unload cannot pin a chunk in memory. The
+ * chunk is resolved on use and skipped if it has gone.
+ */
+public final class LoadedChunks {
+  private static final Map<RegistryKey<World>, Set<Long>> BY_WORLD = new ConcurrentHashMap<>();
+
+  private LoadedChunks() {
+  }
+
+  public static void register() {
+    ServerChunkEvents.CHUNK_LOAD.register((world, chunk) -> positions(world).add(chunk.getPos().toLong()));
+    ServerChunkEvents.CHUNK_UNLOAD.register((world, chunk) -> positions(world).remove(chunk.getPos().toLong()));
+
+    // A world going away takes its whole set with it, so an unloaded dimension does not leak.
+    ServerWorldEvents.UNLOAD.register((server, world) -> BY_WORLD.remove(world.getRegistryKey()));
+  }
+
+  /**
+   * Visits every chunk of this world that is still loaded.
+   *
+   * <p>Iterates a copy of the position set. The action is free to change blocks, which can load or
+   * unload chunks and would otherwise be modifying the set being walked.
+   */
+  public static void forEachChunk(ServerWorld world, Consumer<WorldChunk> action) {
+    for (long position : Set.copyOf(positions(world))) {
+      Chunk chunk = world.getChunk(ChunkPos.getPackedX(position), ChunkPos.getPackedZ(position), ChunkStatus.FULL, false);
+
+      if (chunk instanceof WorldChunk loaded) {
+        action.accept(loaded);
+      }
+    }
+  }
+
+  private static Set<Long> positions(ServerWorld world) {
+    return BY_WORLD.computeIfAbsent(world.getRegistryKey(), key -> ConcurrentHashMap.newKeySet());
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/DayChangingHandler.java
@@ -1,6 +1,7 @@
 package net.abakath.rpg4fools.server.events;
 
 import net.abakath.rpg4fools.enums.Months;
+import net.abakath.rpg4fools.enums.Season;
 import net.abakath.rpg4fools.models.DayData;
 import net.abakath.rpg4fools.network.packets.s2c.SeasonUpdatePacket;
 import net.abakath.rpg4fools.server.SeasonData;
@@ -16,6 +17,15 @@ public class DayChangingHandler implements ServerTickEvents.StartTick {
     private static final int MONTH_DURATION = 28;
     private static final int MONTHS_IN_YEAR = 12;
     private static final int YEAR_DURATION = MONTH_DURATION * MONTHS_IN_YEAR;
+
+    /**
+     * The season as of the last tick, for spotting the moment it turns.
+     *
+     * <p>Null until the first tick, which deliberately skips the sweep on start up: nothing has
+     * changed yet, and a full pass over every loaded chunk is not something to do while a server is
+     * still coming up.
+     */
+    private Season lastSeason = null;
 
     @Override
     public void onStartTick(MinecraftServer server) {
@@ -34,6 +44,12 @@ public class DayChangingHandler implements ServerTickEvents.StartTick {
             // The precipitation mixin reads this on both sides. The server half is set here rather
             // than read back from SeasonData, so the hot path never touches persistent state.
             CurrentSeason.set(dayData.getMonth().getSubSeason());
+
+            Season season = dayData.getMonth().getSubSeason().getSeason();
+            if (lastSeason != null && lastSeason != season) {
+                SeasonChangeSweep.run(server, season);
+            }
+            lastSeason = season;
 
             server.getPlayerManager().getPlayerList().forEach(player -> {
                 DayData.setPlayerDayData((IEntityDataSaver) player, dayData);

--- a/src/main/java/net/abakath/rpg4fools/server/events/SeasonChangeSweep.java
+++ b/src/main/java/net/abakath/rpg4fools/server/events/SeasonChangeSweep.java
@@ -1,0 +1,91 @@
+package net.abakath.rpg4fools.server.events;
+
+import net.abakath.rpg4fools.RPG4Fools;
+import net.abakath.rpg4fools.enums.Season;
+import net.abakath.rpg4fools.server.LoadedChunks;
+import net.abakath.rpg4fools.world.CropSeasons;
+import net.abakath.rpg4fools.world.CropTransition;
+import net.minecraft.block.BlockState;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.chunk.ChunkSection;
+import net.minecraft.world.chunk.WorldChunk;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Settles every loaded crop the moment a season turns.
+ *
+ * <p>A player standing in a wheat field when winter arrives should watch it die, not find it dead
+ * next time it happens to tick. The random tick hook remains for the rest: a farm nobody had loaded
+ * at the turn of the season converts when it comes back, which is the only thing that can be done
+ * about ground the server is not holding.
+ *
+ * <p>Cost is kept off the scan by asking each chunk section whether its palette contains a crop at
+ * all before looking at any position in it. A section is 4096 blocks and almost none of them hold
+ * crops, so nearly every section is dismissed on a palette check.
+ */
+public final class SeasonChangeSweep {
+  /** Blocks along one edge of a chunk section. */
+  private static final int SECTION_SIZE = 16;
+
+  private SeasonChangeSweep() {
+  }
+
+  public static void run(MinecraftServer server, Season season) {
+    for (ServerWorld world : server.getWorlds()) {
+      sweep(world, season);
+    }
+  }
+
+  private static void sweep(ServerWorld world, Season season) {
+    List<BlockPos> crops = new ArrayList<>();
+
+    LoadedChunks.forEachChunk(world, chunk -> collectCrops(chunk, crops));
+
+    int changed = 0;
+    for (BlockPos pos : crops) {
+      // Read the state again rather than trusting the one collected. Setting a block can break a
+      // neighbour, and a stem taken out with its farmland should not then be replaced by a dead
+      // crop standing on nothing.
+      if (CropTransition.apply(world, pos, world.getBlockState(pos), season)) {
+        changed++;
+      }
+    }
+
+    if (changed > 0) {
+      RPG4Fools.LOGGER.info("{} turned {} crop(s) with the change to {}", world.getRegistryKey().getValue(), changed, season.getName());
+    }
+  }
+
+  private static void collectCrops(WorldChunk chunk, List<BlockPos> crops) {
+    ChunkSection[] sections = chunk.getSectionArray();
+
+    for (int index = 0; index < sections.length; index++) {
+      ChunkSection section = sections[index];
+
+      if (section.isEmpty() || !section.hasAny(CropSeasons::isCrop)) {
+        continue;
+      }
+
+      int startX = chunk.getPos().getStartX();
+      int startY = ChunkSectionPos.getBlockCoord(chunk.sectionIndexToCoord(index));
+      int startZ = chunk.getPos().getStartZ();
+
+      for (int y = 0; y < SECTION_SIZE; y++) {
+        for (int z = 0; z < SECTION_SIZE; z++) {
+          for (int x = 0; x < SECTION_SIZE; x++) {
+            BlockState state = section.getBlockState(x, y, z);
+
+            if (CropSeasons.isCrop(state)) {
+              crops.add(new BlockPos(startX + x, startY + y, startZ + z));
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/net/abakath/rpg4fools/world/CropTransition.java
+++ b/src/main/java/net/abakath/rpg4fools/world/CropTransition.java
@@ -1,0 +1,60 @@
+package net.abakath.rpg4fools.world;
+
+import net.abakath.rpg4fools.enums.Season;
+import net.abakath.rpg4fools.init.ModBlocks;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.SweetBerryBushBlock;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * What a season does to a crop already in the ground.
+ *
+ * <p>Two callers ask this: the sweep that runs the moment a season turns, and the random tick hook
+ * that catches whatever was not loaded at the time. Both have to reach the same answer, so the rules
+ * live here rather than in either of them.
+ */
+public class CropTransition {
+  /**
+   * Brings one block into line with the season, and reports whether it changed.
+   *
+   * <p>The crops tag check comes first because the random tick hook calls this for every block in
+   * the game.
+   */
+  public static boolean apply(ServerWorld world, BlockPos pos, BlockState state, Season season) {
+    if (!CropSeasons.isCrop(state)) {
+      return false;
+    }
+
+    boolean inSeason = CropSeasons.isInSeason(state, season);
+
+    // Bushes are the one crop that comes back, so they swap between two blocks instead of dying.
+    if (state.isOf(Blocks.SWEET_BERRY_BUSH)) {
+      if (inSeason) {
+        return false;
+      }
+
+      world.setBlockState(pos, ModBlocks.DORMANT_SWEET_BERRY_BUSH.getDefaultState());
+      return true;
+    }
+
+    if (state.isOf(ModBlocks.DORMANT_SWEET_BERRY_BUSH)) {
+      if (!inSeason) {
+        return false;
+      }
+
+      // Age 1 is leafy with no fruit, so the bush picks up where a fresh one would rather than
+      // handing back the berries it lost going dormant.
+      world.setBlockState(pos, Blocks.SWEET_BERRY_BUSH.getDefaultState().with(SweetBerryBushBlock.AGE, 1));
+      return true;
+    }
+
+    if (inSeason) {
+      return false;
+    }
+
+    world.setBlockState(pos, ModBlocks.DEAD_CROP.getDefaultState());
+    return true;
+  }
+}


### PR DESCRIPTION
Changes the timing decided earlier: crops died lazily, on their next random tick. Now the season change itself does the work.

## What changes

On a season boundary, every **loaded** crop is settled at once — wheat dies while you're standing in the field, bushes go dormant, dormant bushes revive.

The random-tick hook stays for the one case a sweep cannot reach: a farm nobody had loaded at the turn of the season, which converts when it comes back. Nothing can be done about ground the server isn't holding.

## Cost

Two things keep this off the tick budget:

- **Palette check first.** Each chunk section is asked whether it contains a crop at all (`section.hasAny(CropSeasons::isCrop)`) before any position in it is read. A section is 4096 blocks and almost none hold crops, so nearly every section is dismissed on one check.
- **Four times a year.** This runs on `Season` changes, not sub-season or month changes.

## Loaded chunk tracking

`server/LoadedChunks.java`, fed by `ServerChunkEvents.CHUNK_LOAD`/`CHUNK_UNLOAD`. Needed because nothing public enumerates loaded chunks — `ServerChunkManager` looks a chunk up by position but won't list what it holds, and the alternative was a mixin into its internals.

Stores packed positions, not chunk objects, so a missed unload can't pin a chunk in memory; the chunk is resolved on use and skipped if it's gone. `ServerWorldEvents.UNLOAD` drops a whole world's set.

## Shared rules

`world/CropTransition.java` now holds what a season does to a crop — death, dormancy, revival — and both the sweep and the mixin call it. Two callers that could disagree about the rules is exactly the bug worth designing out, and the mixin gets its fast path from the same tag check that opens the method.

## Verification

CI compile only. Two calls I could not check without a JDK, both of which fail loudly if wrong:

- `ChunkSection#hasAny(Predicate<BlockState>)` — a compile error if the signature differs.
- `world.getChunk(x, z, ChunkStatus.FULL, false)` returning null for an unloaded chunk, which is what makes the position-based tracking safe.

In game: stand in a mixed farm and cross a season boundary (`/time add`), watch it convert in one step; walk far away, cross a boundary, come back and confirm the hook caught the rest; check the log line reporting how many crops turned.

Targets #45, which targets #44. #42/#43/#44 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)