### PR TITLE
Give the dormant bush its second plane

### DIFF
--- a/src/main/resources/assets/rpg4fools/models/block/dormant_sweet_berry_bush.json
+++ b/src/main/resources/assets/rpg4fools/models/block/dormant_sweet_berry_bush.json
@@ -18,11 +18,11 @@
     {
       "from": [8, 0, 0.8],
       "to": [8, 16, 15.2],
-      "rotation": { "origin": [8, 8, 8], "axis": "y", "angle": -45, "rescale": true },
+      "rotation": { "origin": [8, 8, 8], "axis": "y", "angle": 45, "rescale": true },
       "shade": false,
       "faces": {
-        "north": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 },
-        "south": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 }
+        "west": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 },
+        "east": { "uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0 }
       }
     }
   ]


### PR DESCRIPTION
Reported: the dormant bush renders one flat sprite instead of an X cross.

## Root cause

Two errors in the hand-written model, both in the second plane. Checked against vanilla `block/cross.json` (1.20.x):

| | vanilla | mine | effect |
|---|---|---|---|
| plane 2 faces | `west`, `east` | `north`, `south` | plane spans `x=8..8`, so it is flat in X — north/south faces have zero area and never render. **This is the missing side.** |
| plane 2 rotation | `45` | `-45` | would have crossed the planes at the wrong angle once visible |

## Fix

Both corrected. Plane 1 was already right.

## Why this model is hand-written at all

`dead_crop` inherits `minecraft:block/cross` and was never affected. The dormant bush can't: the brown tint requires `tintindex` on each face, which the vanilla template doesn't carry. Restating the geometry is what let it be restated wrongly — worth remembering if another tinted cross block shows up, since a shared `rpg4fools:block/tinted_cross` parent would make this a one-time mistake instead of a per-block one.

## Verification

CI compile only; JSON is not compiled, so CI proves nothing about this file — the same blind spot that put the tags in the wrong directory in #41. Needs eyes in game: a dormant bush should read as a proper X from every angle, still browned, matching the shape of a live bush beside it.

Targets #46. Everything below it untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)