### PR TITLE
feat: plant the mod's crops in village farms

### DIFF
--- a/src/main/resources/data/minecraft/worldgen/processor_list/farm_desert.json
+++ b/src/main/resources/data/minecraft/worldgen/processor_list/farm_desert.json
@@ -1,0 +1,89 @@
+{
+  "processors": [
+    {
+      "processor_type": "minecraft:rule",
+      "rules": [
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.2
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:beetroots",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.1
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:melon_stem",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.085
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:tomato_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.085
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:cucumber_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.085
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:lettuce_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/worldgen/processor_list/farm_plains.json
+++ b/src/main/resources/data/minecraft/worldgen/processor_list/farm_plains.json
@@ -1,0 +1,105 @@
+{
+  "processors": [
+    {
+      "processor_type": "minecraft:rule",
+      "rules": [
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.3
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:carrots",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.2
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:potatoes",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.1
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:beetroots",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.125
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:tomato_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.125
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:cucumber_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.125
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:lettuce_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/worldgen/processor_list/farm_savanna.json
+++ b/src/main/resources/data/minecraft/worldgen/processor_list/farm_savanna.json
@@ -1,0 +1,73 @@
+{
+  "processors": [
+    {
+      "processor_type": "minecraft:rule",
+      "rules": [
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.1
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:melon_stem",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.065
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:tomato_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.065
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:cucumber_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.065
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:lettuce_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/worldgen/processor_list/farm_snowy.json
+++ b/src/main/resources/data/minecraft/worldgen/processor_list/farm_snowy.json
@@ -1,0 +1,89 @@
+{
+  "processors": [
+    {
+      "processor_type": "minecraft:rule",
+      "rules": [
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.1
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:carrots",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.8
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:potatoes",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.15
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:tomato_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.15
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:cucumber_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.15
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:lettuce_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/worldgen/processor_list/farm_taiga.json
+++ b/src/main/resources/data/minecraft/worldgen/processor_list/farm_taiga.json
@@ -1,0 +1,89 @@
+{
+  "processors": [
+    {
+      "processor_type": "minecraft:rule",
+      "rules": [
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.3
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:pumpkin_stem",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.2
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "minecraft:potatoes",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.11
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:tomato_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.11
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:cucumber_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        },
+        {
+          "input_predicate": {
+            "block": "minecraft:wheat",
+            "predicate_type": "minecraft:random_block_match",
+            "probability": 0.11
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          },
+          "output_state": {
+            "Name": "rpg4fools:lettuce_crop",
+            "Properties": {
+              "age": "0"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Tomato, cucumber and lettuce now turn up in generated village farms, so a survival player has a route to them without a creative inventory.

## How

Overrides the five vanilla farm processor lists — `farm_plains`, `farm_desert`, `farm_savanna`, `farm_taiga`, `farm_snowy` — rather than the template pools that reference them. The pools would mean restating every vanilla village element and keeping that list correct across versions; the processor lists are three appended rules each, and the rules that decide a farm's crop mix already live there.

Vanilla's rules are kept exactly as they are, with the new ones appended after them. Rules are first-match-wins, so an appended rule only ever sees a plot that survived every vanilla rule — the carrot, potato, beetroot and stem rates are untouched, and the new crops come out of wheat's share alone.

## Rates

The probability differs per list because each leaves a different amount of wheat behind:

| list | wheat left for us | probability each | new crops | wheat after |
|---|---|---|---|---|
| `farm_plains` | 50% | 0.125 | 16.6% | 33.8% |
| `farm_desert` | 72% | 0.085 | 16.8% | 55.2% |
| `farm_savanna` | 90% | 0.065 | 16.4% | 73.6% |
| `farm_taiga` | 56% | 0.11 | 16.5% | 39.5% |
| `farm_snowy` | 18% | 0.15 | 6.9% | 11.1% |

Snowy is the deliberate exception. Only 18% of its plots are still wheat by the time these rules run, so one plot in six would mean no wheat left in a snowy village at all; one in fourteen keeps it the potato field it is meant to be.

## Known gaps

- **Season death.** Village crops obey the seasons like anything else, so a village generated in winter has its tomatoes and cucumbers turn to dead crops on the first tick, and lettuce only survives spring and autumn. Worldgen cannot see the season; closing this needs a second route to the seeds — villager trades or chest loot — not another rule here.
- **Override, not merge.** Any other mod overriding these same five files wins or loses wholesale. There is no merge-friendly route to vanilla farms short of a mixin into the template pools.
- **Bushes are out.** Strawberry, blackberry and blueberry are not farmland plants, so they cannot ride the crop-swap rules at all.

Data only — five JSON files, no code, no mixin. Untested in game: worth generating a fresh world and checking a plains village farm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)